### PR TITLE
Set up travis and codecov integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   include:
   - python: 3.7
     dist: xenial
+    after_success: codecov
   - python: 3.6
     dist: xenial
   - python: 3.5
@@ -19,5 +20,3 @@ install:
   - pip install -e .
 script:
   - make coverage
-after_success:
-  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,22 @@
 sudo: false
 language: python
 cache: pip
-python:
-- 3.5
-- 3.6
-- 3.7
+matrix:
+  include:
+  - python: 3.7
+    dist: xenial
+  - python: 3.6
+    dist: xenial
+  - python: 3.5
+    dist: xenial
 env:
   global:
-  - COVERALLS_PARALLEL=true
-  - LOGGING=info
+    - COVERALLS_PARALLEL=true
+    - LOGGING=info
 install:
-- pip install -r requirements.txt --upgrade
-- pip install wheel pytest pytest-cov codecov --upgrade
-- python3 setup.py bdist_wheel
-- pip install dist/blackbird*.whl
+  - pip install -r requirements.txt --upgrade
+  - pip install wheel pytest pytest-cov codecov --upgrade
 script:
-- make coverage
+  - make coverage
 after_success:
-- codecov
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 install:
   - pip install -r requirements.txt --upgrade
   - pip install wheel pytest pytest-cov codecov --upgrade
+  - pip install -e .
 script:
   - make coverage
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,14 @@ cache: pip
 python:
 - 3.5
 - 3.6
-matrix:
-  include:
-  - python: 3.7
-    dist: xenial
+- 3.7
 env:
   global:
   - COVERALLS_PARALLEL=true
   - LOGGING=info
 install:
-- pip install -r requirements.txt
-- pip install wheel pytest pytest-cov codecov
+- pip install -r requirements.txt --upgrade
+- pip install wheel pytest pytest-cov codecov --upgrade
 - python3 setup.py bdist_wheel
 - pip install dist/blackbird*.whl
 script:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,14 @@
 Blackbird Quantum Assembly Language
 ###################################
 
+.. image:: https://img.shields.io/travis/com/XanaduAI/blackbird/master.svg?style=for-the-badge
+    :alt: Travis
+    :target: https://travis-ci.com/XanaduAI/blackbird/
+
+.. image:: https://img.shields.io/codecov/c/github/xanaduai/blackbird/master.svg?style=for-the-badge
+    :alt: Codecov coverage
+    :target: https://codecov.io/gh/XanaduAI/blackbird
+
 .. image:: https://img.shields.io/readthedocs/quantum-blackbird.svg?style=for-the-badge
     :alt: Read the Docs
     :target: https://quantum-blackbird.readthedocs.io

--- a/blackbird_python/blackbird/tests/test_listener.py
+++ b/blackbird_python/blackbird/tests/test_listener.py
@@ -14,6 +14,8 @@
 
 """Tests for the Blackbird parser/listener"""
 # pylint: disable=too-many-ancestors,no-self-use,redefined-outer-name,no-value-for-parameter
+import sys
+
 import pytest
 
 import numpy as np
@@ -250,6 +252,7 @@ class TestParsingDevice:
 class TestParseFunction:
     """Tests for the `parse_blackbird` convenience parsing function"""
 
+    @pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python >=3.6")
     def test_parse_file(self, tmpdir):
         """Test that device name is extracted"""
         filename = tmpdir.join('test.xbb')


### PR DESCRIPTION
This sets up travis and codecode integration.

This was quick to do, as I could copy the PennyLane boilerplate. However, when I have more time, I will port them to CircleCI (see #3).