### PR TITLE
Adds the ability to serialize a Blackbird program

### DIFF
--- a/apps/strawberry_fields_listener.py
+++ b/apps/strawberry_fields_listener.py
@@ -21,7 +21,7 @@ import numpy as np
 import strawberryfields as sf
 import strawberryfields.ops as sfo
 
-from blackbird import BlackbirdListener, RegRefTransform, parse_blackbird
+from blackbird import BlackbirdListener, RegRefTransform, parse
 
 
 class StrawberryFieldsListener(BlackbirdListener):
@@ -94,7 +94,7 @@ def run(file):
         list: list of size ``[shots, num_subsystems]``, representing
         the measured qumode values for each shot
     """
-    simulation = parse_blackbird(file, listener=StrawberryFieldsListener)
+    simulation = parse(antlr4.FileStream(file), listener=StrawberryFieldsListener)
     simulation.run()
     simulation.print_results()
 

--- a/blackbird_python/blackbird/__init__.py
+++ b/blackbird_python/blackbird/__init__.py
@@ -62,8 +62,31 @@ Modules
 * :mod:`blackbird.auxiliary`: auxiliary parsing functions.
 
 
-Main components
----------------
+Serializing and deserializing Blackbird
+---------------------------------------
+
+The following functions are provided to easily 
+
+* :func:`~.load`: a utility function that automates
+  the de-serialization of the Blackbird script
+  from a file (specified by file location),
+  returning a :class:`~.BlackbirdProgram` object.
+
+* :func:`~.loads`: a utility function that automates
+  the de-serialization of the Blackbird script
+  from a string, returning a :class:`~.BlackbirdProgram` object.
+
+* :func:`~.dump`: a utility function that automates
+  the serialization of a :class:`~.BlackbirdProgram` object
+  to a `.write()`-supporting file-like object.
+
+* :func:`~.dumps`: a utility function that automates
+  the serialization of a :class:`~.BlackbirdProgram` object
+  to a string.
+
+
+Main classes
+------------
 
 * :class:`~.BlackbirdProgram`: a class that encapsulates a Blackbird
   program, using standard Python data structures accessible via attributes.
@@ -81,17 +104,6 @@ Main components
   If the operation argument you are parsing is an instance of this class,
   that indicates that a register transform is required.
 
-* :func:`~.parse_blackbird`: a utility function that automates
-  the parsing of the Blackbird abstract syntax tree from a file.
-  Use this function, either with the default parser
-  :class:`~.BlackbirdListener` or a custom derived class, to parse
-  arbitrary Blackbird code given a file location.
-
-* :func:`~.parse_blackbird_string`: a utility function that automates
-  the parsing of the Blackbird abstract syntax tree from a string.
-  Use this function, either with the default parser
-  :class:`~.BlackbirdListener` or a custom derived class, to parse
-  arbitrary Blackbird code given a string containing valid Blackbird code.
 
 .. note::
 
@@ -100,14 +112,77 @@ Main components
 
   .. code-block:: python
 
-    from blackbird import BlackbirdListener, parse_blackbird, BlackbirdProgram
+    from blackbird import BlackbirdListener, load, BlackbirdProgram
+
+Summary
+-------
+
+.. autosummary::
+    load
+    loads
+    dump
+    dumps
+
+Code details
+^^^^^^^^^^^^
 """
+import antlr4
 
 from .listener import (
     BlackbirdListener,
     RegRefTransform,
-    parse_blackbird,
-    parse_blackbird_string,
+    parse
 )
 from .program import BlackbirdProgram
 from ._version import __version__
+
+
+def load(filename):
+    """Deserialize a blackbird program from a file to a
+    :class:`BlackbirdProgram` object.
+
+    Args:
+        filename (str): file location of a valid Blackbird program
+
+    Returns:
+        BlackbirdProgram: returns a :class:`BlackbirdProgram` object
+    """
+    data = antlr4.FileStream(filename)
+    return parse(data)
+
+
+def loads(string):
+    """Deserialize a blackbird program from a string to a
+    :class:`BlackbirdProgram` object.
+
+    Args:
+        string (str): string containing a valid Blackbird program
+
+    Returns:
+        BlackbirdProgram: returns a :class:`BlackbirdProgram` object
+    """
+    data = antlr4.InputStream(string)
+    return parse(data)
+
+
+def dump(blackbird, f):
+    """Serialize a blackbird program to a `.write()`-supporting file-like object.
+
+    Args:
+        blackbird (BlackbirdProgram): a :class:`BlackbirdProgram` object
+        f (file-like): a `.write()`-supporting file-like object.
+    """
+    text = blackbird.serialize()
+    f.write(text)
+
+
+def dumps(blackbird):
+    """Serialize a blackbird program to a string.
+
+    Args:
+        blackbird (BlackbirdProgram): a :class:`BlackbirdProgram` object
+
+    Returns:
+        str: the serialized Blackbird program
+    """
+    return blackbird.serialize()

--- a/blackbird_python/blackbird/__init__.py
+++ b/blackbird_python/blackbird/__init__.py
@@ -145,7 +145,7 @@ def load(filename):
         filename (str): file location of a valid Blackbird program
 
     Returns:
-        BlackbirdProgram: returns a :class:`BlackbirdProgram` object
+        BlackbirdProgram: parsed representation of the program
     """
     data = antlr4.FileStream(filename)
     return parse(data)

--- a/blackbird_python/blackbird/__init__.py
+++ b/blackbird_python/blackbird/__init__.py
@@ -48,6 +48,10 @@ The Python Blackbird parser is built using the ANTLR listener pattern.
 Modules
 -------
 
+* :mod:`blackbird.program`: the Blackbird program module. Contains
+  the main Blackbird program class, used for encapsulating Blackbird
+  programs in Python.
+
 * :mod:`blackbird.listener`: the Blackbird listener module. Contains
   the main Blackbird listener class, as well as a class for encapsulating
   classical processing of measured modes as register transforms.
@@ -60,6 +64,9 @@ Modules
 
 Main components
 ---------------
+
+* :class:`~.BlackbirdProgram`: a class that encapsulates a Blackbird
+  program, using standard Python data structures accessible via attributes.
 
 * :class:`~.BlackbirdListener`: the Python Blackbird listener,
   that traverses the abstract syntax tree using ANTLR4, evaluating expressions,
@@ -75,19 +82,32 @@ Main components
   that indicates that a register transform is required.
 
 * :func:`~.parse_blackbird`: a utility function that automates
-  the parsing of the Blackbird abstract syntax tree. Use this function, either
-  with the default parser :class:`~.BlackbirdListener` or a custom
-  derived class, to parse arbitrary Blackbird code.
+  the parsing of the Blackbird abstract syntax tree from a file.
+  Use this function, either with the default parser
+  :class:`~.BlackbirdListener` or a custom derived class, to parse
+  arbitrary Blackbird code given a file location.
+
+* :func:`~.parse_blackbird_string`: a utility function that automates
+  the parsing of the Blackbird abstract syntax tree from a string.
+  Use this function, either with the default parser
+  :class:`~.BlackbirdListener` or a custom derived class, to parse
+  arbitrary Blackbird code given a string containing valid Blackbird code.
 
 .. note::
 
-	While both the above classes/functions are located in the :mod:`blackbird.listener`,
-	they are both importable from the top-level of the Blackbird Python package:
+  All the above classes/functions are importable from the top-level
+  of the Blackbird Python package:
 
-	.. code-block:: python
+  .. code-block:: python
 
-		from blackbird import BlackbirdListener, parse_blackbird
+    from blackbird import BlackbirdListener, parse_blackbird, BlackbirdProgram
 """
 
-from .listener import BlackbirdListener, RegRefTransform, parse_blackbird
+from .listener import (
+    BlackbirdListener,
+    RegRefTransform,
+    parse_blackbird,
+    parse_blackbird_string,
+)
+from .program import BlackbirdProgram
 from ._version import __version__

--- a/blackbird_python/blackbird/__init__.py
+++ b/blackbird_python/blackbird/__init__.py
@@ -65,7 +65,7 @@ Modules
 Serializing and deserializing Blackbird
 ---------------------------------------
 
-The following functions are provided to easily 
+The following functions are provided to easily
 
 * :func:`~.load`: a utility function that automates
   the de-serialization of the Blackbird script
@@ -128,11 +128,7 @@ Code details
 """
 import antlr4
 
-from .listener import (
-    BlackbirdListener,
-    RegRefTransform,
-    parse
-)
+from .listener import BlackbirdListener, RegRefTransform, parse
 from .program import BlackbirdProgram
 from ._version import __version__
 
@@ -159,7 +155,7 @@ def loads(string):
         string (str): string containing a valid Blackbird program
 
     Returns:
-        BlackbirdProgram: returns a :class:`BlackbirdProgram` object
+        BlackbirdProgram: parsed representation of the program
     """
     data = antlr4.InputStream(string)
     return parse(data)

--- a/blackbird_python/blackbird/error.py
+++ b/blackbird_python/blackbird/error.py
@@ -47,6 +47,7 @@ Summary
 Code details
 ~~~~~~~~~~~~
 """
+#pylint: disable=too-many-statements, protected-access
 import sys
 import antlr4
 
@@ -62,8 +63,9 @@ class NoTraceBack(Exception):
         Args:
             msg (str): message to be printed in the traceback
         """
+        #pylint: disable=super-init-not-called,unused-argument
         try:
-            ln = sys.exc_info()[-1].tb_lineno
+            _ = sys.exc_info()[-1].tb_lineno
         except AttributeError:
             pass
         sys.exit(self)
@@ -88,21 +90,11 @@ class BlackbirdErrorListener(antlr4.error.ErrorListener.ErrorListener):
             # is returned from the parser. Instead, we can get the context from the parser itself.
             ctx = recognizer._ctx
 
-        if offendingSymbol.text in {
-            ";",
-            "[",
-            "]",
-            "\\",
-            "$",
-            "@",
-            "&",
-            "%",
-            "~",
-            "`",
-            "?",
-        }:
+        if offendingSymbol.text in {";", "[", "]", "\\", "$", "@", "&", "%", "~", "`", "?"}:
             # inform the user of invalid symbol usage
-            error_msg = "Blackbird SyntaxError (line {}:{}): {} is not a valid Blackbird symbol."
+            error_msg = (
+                "Blackbird SyntaxError (line {}:{}): {} is not a valid Blackbird symbol."
+            )
             raise BlackbirdSyntaxError(
                 error_msg.format(line, column + 1, offendingSymbol.text)
             ) from None
@@ -115,7 +107,9 @@ class BlackbirdErrorListener(antlr4.error.ErrorListener.ErrorListener):
 
             if not ctx.ASSIGN():
                 # equal sign was not found
-                error_msg = "Blackbird SyntaxError (line {}:{}): variable {} missing an assignment."
+                error_msg = (
+                    "Blackbird SyntaxError (line {}:{}): variable {} missing an assignment."
+                )
                 raise BlackbirdSyntaxError(
                     error_msg.format(line, column + 1, var_name)
                 ) from None

--- a/blackbird_python/blackbird/error.py
+++ b/blackbird_python/blackbird/error.py
@@ -47,7 +47,7 @@ Summary
 Code details
 ~~~~~~~~~~~~
 """
-#pylint: disable=too-many-statements, protected-access
+# pylint: disable=too-many-statements, protected-access
 import sys
 import antlr4
 
@@ -63,7 +63,7 @@ class NoTraceBack(Exception):
         Args:
             msg (str): message to be printed in the traceback
         """
-        #pylint: disable=super-init-not-called,unused-argument
+        # pylint: disable=super-init-not-called,unused-argument
         try:
             _ = sys.exc_info()[-1].tb_lineno
         except AttributeError:
@@ -90,23 +90,9 @@ class BlackbirdErrorListener(antlr4.error.ErrorListener.ErrorListener):
             # is returned from the parser. Instead, we can get the context from the parser itself.
             ctx = recognizer._ctx
 
-        if offendingSymbol.text in {
-            ";",
-            "[",
-            "]",
-            "\\",
-            "$",
-            "@",
-            "&",
-            "%",
-            "~",
-            "`",
-            "?",
-        }:
+        if offendingSymbol.text in {";", "[", "]", "\\", "$", "@", "&", "%", "~", "`", "?"}:
             # inform the user of invalid symbol usage
-            error_msg = (
-                "Blackbird SyntaxError (line {}:{}): {} is not a valid Blackbird symbol."
-            )
+            error_msg = "Blackbird SyntaxError (line {}:{}): {} is not a valid Blackbird symbol."
             raise BlackbirdSyntaxError(
                 error_msg.format(line, column + 1, offendingSymbol.text)
             ) from None
@@ -119,19 +105,13 @@ class BlackbirdErrorListener(antlr4.error.ErrorListener.ErrorListener):
 
             if not ctx.ASSIGN():
                 # equal sign was not found
-                error_msg = (
-                    "Blackbird SyntaxError (line {}:{}): variable {} missing an assignment."
-                )
-                raise BlackbirdSyntaxError(
-                    error_msg.format(line, column + 1, var_name)
-                ) from None
+                error_msg = "Blackbird SyntaxError (line {}:{}): variable {} missing an assignment."
+                raise BlackbirdSyntaxError(error_msg.format(line, column + 1, var_name)) from None
 
             if offendingSymbol.text == "\n":
                 # expression terminated midway by a new line
                 error_msg = "Blackbird SyntaxError (line {}:{}): variable {} has an incomplete value or expression"
-                raise BlackbirdSyntaxError(
-                    error_msg.format(line, column + 1, var_name)
-                ) from None
+                raise BlackbirdSyntaxError(error_msg.format(line, column + 1, var_name)) from None
 
             # otherwise, return a more generic variable error
             syntax_msg = (
@@ -139,9 +119,7 @@ class BlackbirdErrorListener(antlr4.error.ErrorListener.ErrorListener):
                 "symbol {} which is not a valid {}."
             )
             raise BlackbirdSyntaxError(
-                syntax_msg.format(
-                    line, column + 1, var_name, offendingSymbol.text, var_type
-                )
+                syntax_msg.format(line, column + 1, var_name, offendingSymbol.text, var_type)
             ) from None
 
         if isinstance(ctx, blackbirdParser.ArrayvarContext):
@@ -154,9 +132,7 @@ class BlackbirdErrorListener(antlr4.error.ErrorListener.ErrorListener):
                     "Blackbird SyntaxError (line {}:{}): array declaration requires a new line after '=', "
                     "followed by the indented and comma-separated array values."
                 )
-                raise BlackbirdSyntaxError(
-                    error_msg.format(line, column + 1, var_name)
-                ) from None
+                raise BlackbirdSyntaxError(error_msg.format(line, column + 1, var_name)) from None
 
         # iterate up through the tree, and determine if we are in an array declaration
         parent_ctx = ctx
@@ -170,9 +146,7 @@ class BlackbirdErrorListener(antlr4.error.ErrorListener.ErrorListener):
                 var_name = parent_ctx.name().getText()
                 syntax_msg = "Blackbird SyntaxError (line {}:{}): - array {} contains the symbol {} is not a valid {}."
                 raise BlackbirdSyntaxError(
-                    syntax_msg.format(
-                        line, column + 1, var_name, offendingSymbol.text, var_type
-                    )
+                    syntax_msg.format(line, column + 1, var_name, offendingSymbol.text, var_type)
                 ) from None
 
         if isinstance(ctx, blackbirdParser.StatementContext):
@@ -184,12 +158,8 @@ class BlackbirdErrorListener(antlr4.error.ErrorListener.ErrorListener):
 
             if msg == "mismatched input '\\n' expecting {INT, '(', '['}":
                 # there are no modes provided, raise an error
-                error_msg = (
-                    "Blackbird SyntaxError (line {}:{}): statement {} is missing modes."
-                )
-                raise BlackbirdSyntaxError(
-                    error_msg.format(line, column + 1, op_name)
-                ) from None
+                error_msg = "Blackbird SyntaxError (line {}:{}): statement {} is missing modes."
+                raise BlackbirdSyntaxError(error_msg.format(line, column + 1, op_name)) from None
 
             if "expecting {NEWLINE, ')', ']'}" in msg:
                 # there are additional integer mode numbers provided, but they are not comma separated,
@@ -203,13 +173,17 @@ class BlackbirdErrorListener(antlr4.error.ErrorListener.ErrorListener):
         if isinstance(ctx, blackbirdParser.StartContext):
             if "expecting {NEWLINE, 'name'}" in msg:
                 # no name metadata
-                error_msg = "Blackbird SyntaxError (line {}:{}): blackbird 'name' statement is missing."
+                error_msg = (
+                    "Blackbird SyntaxError (line {}:{}): blackbird 'name' statement is missing."
+                )
                 raise BlackbirdSyntaxError(error_msg.format(line, column + 1)) from None
 
         if isinstance(ctx, blackbirdParser.MetadatablockContext):
             if "expecting {NEWLINE, 'version'}" in msg:
                 # no name metadata
-                error_msg = "Blackbird SyntaxError (line {}:{}): blackbird 'version' statement is missing."
+                error_msg = (
+                    "Blackbird SyntaxError (line {}:{}): blackbird 'version' statement is missing."
+                )
                 raise BlackbirdSyntaxError(error_msg.format(line, column + 1)) from None
 
         # otherwise, return a general syntax error, and pass through the original ANTLR4 error message.

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -167,38 +167,6 @@ class BlackbirdListener(blackbirdListener):
 
         self._program._target["options"] = kwargs
 
-    def exitDeclarename(self, ctx: blackbirdParser.DeclarenameContext):
-        """Run after exiting program name metadata.
-
-        Args:
-            ctx: DeclarenameContext
-        """
-        self.name = ctx.programname().getText()
-
-    def exitVersion(self, ctx: blackbirdParser.VersionContext):
-        """Run after exiting version metadata.
-
-        Args:
-            ctx: VersionContext
-        """
-        self.version = ctx.versionnumber().getText()
-
-    def exitTarget(self, ctx: blackbirdParser.TargetContext):
-        """Run after exiting target metadata.
-
-        Args:
-            ctx: TargetContext
-        """
-        self.target = {"name": ctx.device().getText()}
-
-        args = []
-        kwargs = {}
-
-        if ctx.arguments():
-            args, kwargs = _get_arguments(ctx.arguments())
-
-        self.target["options"] = kwargs
-
     def exitExpressionvar(self, ctx: blackbirdParser.ExpressionvarContext):
         """Run after exiting an expression variable.
 

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -36,7 +36,7 @@ Summary
     NUMPY_TYPES
     RegRefTransform
     BlackbirdListener
-    parse_blackbird
+    parse
 
 Code details
 ~~~~~~~~~~~~
@@ -318,49 +318,19 @@ class BlackbirdListener(blackbirdListener):
         _VAR.clear()
 
 
-def parse_blackbird(file, listener=BlackbirdListener):
-    """Parse a blackbird program from a file.
+def parse(data, listener=BlackbirdListener):
+    """Parse a blackbird data stream.
 
     Args:
-        file (str): location of the .xbb blackbird file to run
+        data (antlr4.InputStream): ANTLR4 data stream of the Blackbird script
         Listener (BlackbirdListener): an Blackbird listener to use to walk the AST.
             By default, the basic :class:`~.BlackbirdListener` defined above
             is used.
 
     Returns:
-        BlackbirdListener: returns the Blackbird listener instance after
+        BlackbirdProgram: returns an instance of the :class:`BlackbirdProgram` class after
         parsing the abstract syntax tree
     """
-    data = antlr4.FileStream(file)
-    lexer = blackbirdLexer(data)
-    stream = antlr4.CommonTokenStream(lexer)
-
-    parser = blackbirdParser(stream)
-    parser.removeErrorListeners()
-    parser.addErrorListener(BlackbirdErrorListener())
-    tree = parser.start()
-
-    blackbird = listener()
-    walker = antlr4.ParseTreeWalker()
-    walker.walk(blackbird, tree)
-
-    return blackbird.program
-
-
-def parse_blackbird_string(string, listener=BlackbirdListener):
-    """Parse a blackbird program from a string.
-
-    Args:
-        string (str): string containing a valid Blackbird program.
-        Listener (BlackbirdListener): an Blackbird listener to use to walk the AST.
-            By default, the basic :class:`~.BlackbirdListener` defined above
-            is used.
-
-    Returns:
-        BlackbirdListener: returns the Blackbird listener instance after
-        parsing the abstract syntax tree
-    """
-    data = antlr4.InputStream(string)
     lexer = blackbirdLexer(data)
     stream = antlr4.CommonTokenStream(lexer)
 

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -41,7 +41,9 @@ Summary
 Code details
 ~~~~~~~~~~~~
 """
-#pylint: disable=protected-access
+# pylint: disable=protected-access
+import warnings
+
 import antlr4
 
 import numpy as np
@@ -163,7 +165,15 @@ class BlackbirdListener(blackbirdListener):
         kwargs = {}
 
         if ctx.arguments():
-            _, kwargs = _get_arguments(ctx.arguments())
+            args, kwargs = _get_arguments(ctx.arguments())
+
+            if args:
+                warnings.warn(
+                    "Target devices only accept keyword options of the form "
+                    "option=value. All positional arguments without a named "
+                    "option will be ignored.",
+                    SyntaxWarning,
+                )
 
         self._program._target["options"] = kwargs
 
@@ -298,9 +308,7 @@ class BlackbirdListener(blackbirdListener):
             op_args, op_kwargs = _get_arguments(ctx.arguments())
 
             # convert any sympy expressions into regref transforms
-            op_args = [
-                RegRefTransform(i) if isinstance(i, sym.Expr) else i for i in op_args
-            ]
+            op_args = [RegRefTransform(i) if isinstance(i, sym.Expr) else i for i in op_args]
 
             self._program._operations.append(
                 {"op": op, "args": op_args, "kwargs": op_kwargs, "modes": modes}

--- a/blackbird_python/blackbird/program.py
+++ b/blackbird_python/blackbird/program.py
@@ -1,0 +1,289 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=too-many-return-statements,too-many-branches,too-many-instance-attributes
+"""
+Blackbird Program class
+=======================
+
+**Module name:** `blackbird.program`
+
+.. currentmodule:: blackbird.program
+
+This module contains a Python class representing a Blackbird
+program using standard Python data types.
+
+The :func:`parse_blackbird`
+
+Summary
+-------
+
+.. autosummary::
+    numpy_to_blackbird
+    BlackbirdProgram
+
+Code details
+~~~~~~~~~~~~
+"""
+import numpy as np
+
+
+def numpy_to_blackbird(A, var_name):
+    """Converts a numpy array to a Blackbird script array type.
+
+    Args:
+        A (array): 2-dimensional NumPy array
+        var_name (str): the array variable name
+
+    Returns:
+        list[str]: list containing each line representing the
+            Blackbird array variable declaration
+    """
+
+    if np.any(np.iscomplex(A)):
+        # complex array
+        script = ["complex array {}[{}, {}] =".format(var_name, *A.shape)]
+        for row in A:
+            row_str = "    " + ", ".join(
+                ["{0}{1}{2}j".format(n.real, "+-"[n.imag < 0], abs(n.imag)) for n in row]
+            )
+            script.append(row_str)
+
+    elif np.all(np.mod(A, 1) == 0):
+        # integer array
+        script = ["int array {}[{}, {}] =".format(var_name, *A.shape)]
+        for row in A:
+            row_str = "    " + ", ".join(["{}".format(int(n)) for n in row])
+            script.append(row_str)
+
+    elif not np.any(np.iscomplex(A)):
+        # real array
+        script = ["float array {}[{}, {}] =".format(var_name, *A.shape)]
+        for row in A:
+            row_str = "    " + ", ".join(["{}".format(n) for n in row])
+            script.append(row_str)
+
+    script.append("")
+
+    return script
+
+
+class BlackbirdProgram:
+    """Python representation of a Blackbird program."""
+
+    def __init__(self, name="blackbird_program", version=1.0):
+        self._var = {}
+        self._modes = set()
+
+        # the following attributes fully describe a Blackbird program
+        self._name = name
+        self._version = version
+        self._target = {"name": None, "options": dict()}
+        self._operations = []
+
+    @property
+    def name(self):
+        """Name of the Blackbird program
+
+        Returns:
+            str: name
+        """
+        return self._name
+
+    @property
+    def version(self):
+        """Version of the Blackbird parser the program targets
+
+        Returns:
+            float: version number
+        """
+        return self._version
+
+    @property
+    def modes(self):
+        """A set of non-negative integers specifying the mode numbers the program manipulates.
+
+        Returns:
+            set[int]: mode numbers
+        """
+        return self._modes
+
+    @property
+    def target(self):
+        """Contains information regarding the target device of the quantum
+        program (i.e., the target device the Blackbird script is compiled for).
+
+        Important keys include:
+
+        * ``'name'`` (str): the name of the device the Blackbird script requests to be
+            run on. If no target is requested, the returned value will be ``None``.
+        * ``'options'`` (dict): a dictionary of keyword arguments for the target device
+
+        Returns:
+            dict[str->[str, dict]]: target information
+        """
+        return self._target
+
+    @property
+    def operations(self):
+        """List of operations to apply to the device, in temporal order.
+
+        Each operation is contained as a dictionary, with the following keys:
+
+        * ``'op'`` (str): the name of the operation
+        * ``'args'`` (list): a list of positional arguments for the operation
+        * ``'kwargs'`` (dict): a dictionary of keyword arguments for the operation
+        * ``'modes'`` (list[int]): modes the operation applies to
+
+        Note that, depending on the operation, both ``'args'`` and ``'kwargs'``
+        might be empty.
+
+        Returns:
+            list[dict]: operation information
+        """
+        return self._operations
+
+    def __len__(self):
+        """The length of the quantum program (i.e., the number of operations applied).
+
+        Returns:
+            int: program length
+        """
+        return len(self._operations)
+
+    def serialize(self):
+        """Serializes the blackbird program, returning a valid Blackbird script
+        as a string.
+
+        Returns:
+            str: the blackbird script representing the BlackbirdProgram object
+        """
+        # top level metadata
+        var_count = 0
+        array_insert = 3
+
+        script = ["name {}".format(self.name), "version {}".format(self.version)]
+
+        if self.target["name"] is not None:
+            array_insert += 1
+            options = ""
+
+            if self.target["options"]:
+                # if the target has options, compile them into
+                # the expected syntax
+                option_strings = [
+                    "{}={}".format(k, v)
+                    if not isinstance(v, str)
+                    else '{}="{}"'.format(k, v)
+                    for k, v in self.target["options"].items()
+                ]
+                options = " ({})".format(", ".join(option_strings))
+
+            # add target metadata
+            script.append("target {}{}".format(self.target["name"], options))
+
+        # line break
+        script.append("")
+
+
+        # loop through each quantum operation
+        for op in self.operations:
+            if len(op["modes"]) == 1:
+                modes = op["modes"][0]
+            else:
+                modes = op["modes"]
+
+            # check if the operation has any arguments
+            if "args" in op:
+                args = []
+                kwargs = []
+
+                # loop through position arguments
+                for v in op["args"]:
+                    # for each operation argument, format it
+                    # correctly depending on its type
+                    if isinstance(v, np.ndarray):
+                        # create an array variable
+                        var_name = "A{}".format(var_count)
+                        args.append(var_name)
+                        var_count += 1
+
+                        # add array declaration to script after the metadata block
+                        bb_array = numpy_to_blackbird(v, var_name)
+                        for idx, line in enumerate(bb_array):
+                            script.insert(array_insert + idx, line)
+
+                        array_insert += len(bb_array)
+
+                    elif isinstance(v, str):
+                        # argument is a string type
+                        args.append('"{}"'.format(v))
+
+                    elif isinstance(v, complex):
+                        # argument is a complex type
+                        args.append(
+                            "{}{}{}j".format(v.real, "+-"[v.imag < 0], np.abs(v.imag))
+                        )
+
+                    else:
+                        args.append("{}".format(v))
+
+                # loop through keyword argument
+                for k, v in op["kwargs"].items():
+                    # for each operation argument, format it
+                    # correctly depending on its type
+                    if isinstance(v, np.ndarray):
+                        # create an array variable
+                        var_name = "A{}".format(var_count)
+                        kwargs.append('{}={}'.format(k, var_name))
+                        var_count += 1
+
+                        # add array declaration to script
+                        bb_array = numpy_to_blackbird(v, var_name)
+                        for idx, line in enumerate(bb_array):
+                            script.insert(array_insert + idx, line)
+
+                        array_insert += len(bb_array)
+
+                    elif isinstance(v, str):
+                        kwargs.append('{}="{}"'.format(k, v))
+
+                    elif isinstance(v, complex):
+                        kwargs.append(
+                            "{}={}{}{}j".format(k, v.real, "+-"[v.imag < 0], np.abs(v.imag))
+                        )
+
+                    else:
+                        kwargs.append("{}={}".format(k, v))
+
+                if args and kwargs:
+                    # arguments = "({}, {})".format(", ".join(args), ", ".join(kwargs))
+                    raise ValueError(
+                        "Blackbird currently doesn't support operations "
+                        "which contain both positional and keyword arguments. "
+                        "\nPlease provide all operation arguments as keyword arguments for now."
+                    )
+                elif not kwargs:
+                    arguments = "({})".format(", ".join(args))
+                elif not args:
+                    arguments = "({})".format(", ".join(kwargs))
+
+                script.append("{}{} | {}".format(op["op"], arguments, modes))
+            else:
+                script.append("{} | {}".format(op["op"], modes))
+
+        if script[-1] != "":
+            # add a newline
+            script.append("")
+
+        return "\n".join(script)

--- a/blackbird_python/blackbird/program.py
+++ b/blackbird_python/blackbird/program.py
@@ -23,7 +23,8 @@ Blackbird Program class
 This module contains a Python class representing a Blackbird
 program using standard Python data types.
 
-The :func:`parse_blackbird`
+The functions :func:`~.load`, and :func:`~.loads` will read Blackbird scripts
+and return an instance of the :class:`BlackbirdProgram` class.
 
 Summary
 -------
@@ -55,7 +56,7 @@ def numpy_to_blackbird(A, var_name):
         script = ["complex array {}[{}, {}] =".format(var_name, *A.shape)]
         for row in A:
             row_str = "    " + ", ".join(
-                ["{0}{1}{2}j".format(n.real, "+-"[n.imag < 0], abs(n.imag)) for n in row]
+                ["{0}{1}{2}j".format(n.real, "+-"[int(n.imag < 0)], abs(n.imag)) for n in row]
             )
             script.append(row_str)
 
@@ -232,7 +233,7 @@ class BlackbirdProgram:
                     elif isinstance(v, complex):
                         # argument is a complex type
                         args.append(
-                            "{}{}{}j".format(v.real, "+-"[v.imag < 0], np.abs(v.imag))
+                            "{}{}{}j".format(v.real, "+-"[int(v.imag < 0)], np.abs(v.imag))
                         )
 
                     else:
@@ -260,7 +261,7 @@ class BlackbirdProgram:
 
                     elif isinstance(v, complex):
                         kwargs.append(
-                            "{}={}{}{}j".format(k, v.real, "+-"[v.imag < 0], np.abs(v.imag))
+                            "{}={}{}{}j".format(k, v.real, "+-"[int(v.imag < 0)], np.abs(v.imag))
                         )
 
                     else:

--- a/blackbird_python/blackbird/tests/test_listener.py
+++ b/blackbird_python/blackbird/tests/test_listener.py
@@ -28,8 +28,7 @@ from blackbird.blackbirdParser import blackbirdParser
 from blackbird.listener import (
     BlackbirdListener,
     RegRefTransform,
-    parse_blackbird,
-    parse_blackbird_string
+    parse
 )
 
 
@@ -312,7 +311,7 @@ class TestRegRefTransform:
 
 
 class TestParseFunction:
-    """Tests for the `parse_blackbird` convenience parsing function"""
+    """Tests for the `parse` convenience parsing function"""
 
     @pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python >=3.6")
     def test_parse_file(self, tmpdir):
@@ -322,7 +321,7 @@ class TestParseFunction:
         with open(filename, 'w') as f:
             f.write(test_file)
 
-        bb = parse_blackbird(filename)
+        bb = parse(antlr4.FileStream(filename))
 
         assert bb._var == {"alpha": 0.3423}
 
@@ -336,9 +335,9 @@ class TestParseFunction:
 
         assert bb.operations == expected
 
-    def test_parse_string(self, tmpdir):
+    def test_parse_string(self):
         """Test that device name is extracted"""
-        bb = parse_blackbird_string(test_file)
+        bb = parse(antlr4.InputStream(test_file))
 
         assert bb._var == {"alpha": 0.3423}
 

--- a/blackbird_python/blackbird/tests/test_listener.py
+++ b/blackbird_python/blackbird/tests/test_listener.py
@@ -25,11 +25,7 @@ import antlr4
 
 from blackbird.blackbirdLexer import blackbirdLexer
 from blackbird.blackbirdParser import blackbirdParser
-from blackbird.listener import (
-    BlackbirdListener,
-    RegRefTransform,
-    parse
-)
+from blackbird.listener import BlackbirdListener, RegRefTransform, parse
 
 
 test_file = """
@@ -47,6 +43,7 @@ MeasureFock() | 0
 @pytest.fixture
 def parse_input():
     """Create a parser for the test"""
+
     def _parse_input(text):
         """The parser fixture accepts a blackbird string to parse"""
         lexer = blackbirdLexer(antlr4.InputStream(text))
@@ -59,12 +56,14 @@ def parse_input():
         walker = antlr4.ParseTreeWalker()
         walker.walk(bb, tree)
         return bb.program
+
     return _parse_input
 
 
 @pytest.fixture
 def parse_input_mocked_metadata(monkeypatch):
     """Create a parser for the test that mocks out the metadata"""
+
     def _parse_input(text):
         """The parser fixture accepts a blackbird string to parse"""
         text = "name mockname\nversion 1.0\n" + text
@@ -79,6 +78,7 @@ def parse_input_mocked_metadata(monkeypatch):
         walker.walk(bb, tree)
 
         return bb.program
+
     return _parse_input
 
 
@@ -88,7 +88,7 @@ class TestParsingVariables:
     def test_invalid_regref(self, parse_input_mocked_metadata):
         """Test that a variable using the reserved name for regrefs returns an exception"""
         with pytest.raises(SystemExit, match="reserved for register references"):
-            parse_input_mocked_metadata('float q0 = 5')
+            parse_input_mocked_metadata("float q0 = 5")
 
         with pytest.raises(SystemExit, match="reserved for register references"):
             parse_input_mocked_metadata("float array q4 =\n\t-0.1, 0.2")
@@ -96,77 +96,85 @@ class TestParsingVariables:
     def test_invalid_variable_name(self, parse_input_mocked_metadata):
         """Test that a variable using the reserved name for a blackbird keyword returns an exception"""
         with pytest.raises(SystemExit, match="reserved Blackbird keyword"):
-            parse_input_mocked_metadata('float name = 5')
+            parse_input_mocked_metadata("float name = 5")
 
         with pytest.raises(SystemExit, match="reserved Blackbird keyword"):
-            parse_input_mocked_metadata('float target = 5')
+            parse_input_mocked_metadata("float target = 5")
 
         with pytest.raises(SystemExit, match="reserved Blackbird keyword"):
-            parse_input_mocked_metadata('float version = 5')
+            parse_input_mocked_metadata("float version = 5")
 
         with pytest.raises(SystemExit, match="reserved Blackbird keyword"):
-            parse_input_mocked_metadata('float array name =\n\t-0.1, 0.2')
+            parse_input_mocked_metadata("float array name =\n\t-0.1, 0.2")
 
         with pytest.raises(SystemExit, match="reserved Blackbird keyword"):
-            parse_input_mocked_metadata('float array target =\n\t-0.1, 0.2')
+            parse_input_mocked_metadata("float array target =\n\t-0.1, 0.2")
 
         with pytest.raises(SystemExit, match="reserved Blackbird keyword"):
-            parse_input_mocked_metadata('float array version =\n\t-0.1, 0.2')
+            parse_input_mocked_metadata("float array version =\n\t-0.1, 0.2")
 
     def test_integer_variable(self, parse_input_mocked_metadata):
         """Test that an integer variable is correctly parsed"""
-        bb = parse_input_mocked_metadata('int n = 5')
-        assert bb._var == {'n': 5}
+        bb = parse_input_mocked_metadata("int n = 5")
+        assert bb._var == {"n": 5}
 
     def test_float_variable(self, parse_input_mocked_metadata):
         """Test that a float variable is correctly parsed"""
         bb = parse_input_mocked_metadata("float alpha = -0.5432")
-        assert bb._var == {'alpha': -0.5432}
+        assert bb._var == {"alpha": -0.5432}
 
     def test_float_exponent_variable(self, parse_input_mocked_metadata):
         """Test that a float variable with an exponent is correctly parsed"""
         bb = parse_input_mocked_metadata("float alpha = -9.54e-3")
-        assert bb._var == {'alpha': -9.54e-3}
+        assert bb._var == {"alpha": -9.54e-3}
 
     def test_complex_variable(self, parse_input_mocked_metadata):
         """Test that a complex variable is correctly parsed"""
         bb = parse_input_mocked_metadata("complex Beta = -0.231+5.21j")
-        assert bb._var == {'Beta': -0.231+5.21j}
+        assert bb._var == {"Beta": -0.231 + 5.21j}
 
     def test_complex_exponent_variable(self, parse_input_mocked_metadata):
         """Test that a complex variable with an exponent is correctly parsed"""
         bb = parse_input_mocked_metadata("complex Beta = -0.231e-6+5.21e-2j")
-        assert bb._var == {'Beta': -0.231e-6+5.21e-2j}
+        assert bb._var == {"Beta": -0.231e-6 + 5.21e-2j}
 
     def test_pi_variable(self, parse_input_mocked_metadata):
         """Test that pi can be parsed"""
         bb = parse_input_mocked_metadata("float test = pi")
-        assert bb._var == {'test': np.pi}
+        assert bb._var == {"test": np.pi}
 
     def test_string_variable(self, parse_input_mocked_metadata):
         """Test that string can be parsed"""
         bb = parse_input_mocked_metadata('str username = "Josh"')
-        assert bb._var == {'username': "Josh"}
+        assert bb._var == {"username": "Josh"}
 
     def test_bool_variable(self, parse_input_mocked_metadata):
         """Test that bool can be parsed"""
-        bb = parse_input_mocked_metadata('bool b1 = True\n bool b2 = False')
-        assert bb._var == {'b1': True, 'b2': False}
+        bb = parse_input_mocked_metadata("bool b1 = True\n bool b2 = False")
+        assert bb._var == {"b1": True, "b2": False}
 
     def test_float_array_variable(self, parse_input_mocked_metadata):
         """Test that float array can be parsed"""
         bb = parse_input_mocked_metadata("float array C =\n\t-0.1, 0.2")
-        assert np.all(bb._var['C'] == np.array([[-0.1, 0.2]]))
+        assert np.all(bb._var["C"] == np.array([[-0.1, 0.2]]))
 
     def test_complex_array_variable(self, parse_input_mocked_metadata):
         """Test that complex array can be parsed"""
-        bb = parse_input_mocked_metadata("complex array A =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j")
-        assert np.all(bb._var['A'] == np.array([[-1.0+1.0j, 2.7e5+0.2e-5j], [-0.1-2j, 0.2-0.1j]]))
+        bb = parse_input_mocked_metadata(
+            "complex array A =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j"
+        )
+        assert np.all(
+            bb._var["A"] == np.array([[-1.0 + 1.0j, 2.7e5 + 0.2e-5j], [-0.1 - 2j, 0.2 - 0.1j]])
+        )
 
     def test_complex_array_shape_variable(self, parse_input_mocked_metadata):
         """Test that complex array with shape can be parsed"""
-        bb = parse_input_mocked_metadata("complex array A[2, 2] =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j")
-        assert np.all(bb._var['A'] == np.array([[-1.0+1.0j, 2.7e5+0.2e-5j], [-0.1-2j, 0.2-0.1j]]))
+        bb = parse_input_mocked_metadata(
+            "complex array A[2, 2] =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j"
+        )
+        assert np.all(
+            bb._var["A"] == np.array([[-1.0 + 1.0j, 2.7e5 + 0.2e-5j], [-0.1 - 2j, 0.2 - 0.1j]])
+        )
 
     def test_invalid_expression_type(self, parse_input_mocked_metadata):
         """Test exception is raised if the expression variable type is incorrect"""
@@ -176,23 +184,33 @@ class TestParsingVariables:
     def test_invalid_array_type(self, parse_input_mocked_metadata):
         """Test exception is raised if the array variable type is incorrect"""
         with pytest.raises(SystemExit, match=r"not of declared type float"):
-            parse_input_mocked_metadata("float array A =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j")
+            parse_input_mocked_metadata(
+                "float array A =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j"
+            )
 
     def test_invalid_array_shape(self, parse_input_mocked_metadata):
         """Test exception is raised if the array variable shape is incorrect"""
-        with pytest.raises(SystemExit, match=r"has declared shape \(1, 2\) but actual shape \(2, 2\)"):
-            parse_input_mocked_metadata("complex array A[1, 2] =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j")
+        with pytest.raises(
+            SystemExit, match=r"has declared shape \(1, 2\) but actual shape \(2, 2\)"
+        ):
+            parse_input_mocked_metadata(
+                "complex array A[1, 2] =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j"
+            )
 
     def test_variable_expression(self, parse_input_mocked_metadata):
         """Test that a variable expression is correctly parsed"""
-        bb = parse_input_mocked_metadata("float alpha = 0.32\nfloat gamma = (2.0*cos(alpha*pi)+1)**2")
-        assert bb._var['gamma'] == (2.0*np.cos(0.32*np.pi)+1)**2
+        bb = parse_input_mocked_metadata(
+            "float alpha = 0.32\nfloat gamma = (2.0*cos(alpha*pi)+1)**2"
+        )
+        assert bb._var["gamma"] == (2.0 * np.cos(0.32 * np.pi) + 1) ** 2
 
     def test_array_variable_expression(self, parse_input_mocked_metadata):
         """Test that a variable expression containing arrays is correctly parsed"""
-        bb = parse_input_mocked_metadata("complex array A =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j\ncomplex res = (2.0*cos(A*pi)+1)**2")
-        A = np.array([[-1.0+1.0j, 2.7e5+0.2e-5j], [-0.1-2j, 0.2-0.1j]])
-        assert np.all(bb._var['res'] == (2.0*np.cos(A*np.pi)+1)**2)
+        bb = parse_input_mocked_metadata(
+            "complex array A =\n\t-1.0+1.0j, 2.7e5+0.2e-5j\n\t-0.1-2j, 0.2-0.1j\ncomplex res = (2.0*cos(A*pi)+1)**2"
+        )
+        A = np.array([[-1.0 + 1.0j, 2.7e5 + 0.2e-5j], [-0.1 - 2j, 0.2 - 0.1j]])
+        assert np.all(bb._var["res"] == (2.0 * np.cos(A * np.pi) + 1) ** 2)
 
 
 class TestParsingQuantumPrograms:
@@ -201,39 +219,47 @@ class TestParsingQuantumPrograms:
     def test_operation_no_args(self, parse_input_mocked_metadata):
         """Test that an operation with no arguments is correctly parsed"""
         bb = parse_input_mocked_metadata("Vac | 0\n")
-        assert bb.operations == [{'modes': [0], 'op': 'Vac'}]
+        assert bb.operations == [{"modes": [0], "op": "Vac"}]
 
     def test_measure_no_args(self, parse_input_mocked_metadata):
         """Test that a measurement with no args is correctly parsed"""
         bb = parse_input_mocked_metadata("Measure | 0\n")
-        assert bb.operations == [{'modes': [0], 'op': 'Measure'}]
+        assert bb.operations == [{"modes": [0], "op": "Measure"}]
 
-    @pytest.mark.parametrize('modes', ['[0, 1, 2, 5]', '0, 1, 2, 5'])
+    @pytest.mark.parametrize("modes", ["[0, 1, 2, 5]", "0, 1, 2, 5"])
     def test_multiple_modes(self, parse_input_mocked_metadata, modes):
         """Test that multiple modes are correctly parsed"""
         bb = parse_input_mocked_metadata("Vac | {}\n".format(modes))
-        assert bb.operations == [{'modes': [0, 1, 2, 5], 'op': 'Vac'}]
+        assert bb.operations == [{"modes": [0, 1, 2, 5], "op": "Vac"}]
 
-    @pytest.mark.parametrize('arg', ['-0.3+2j', '0', '1e-3'])
+    @pytest.mark.parametrize("arg", ["-0.3+2j", "0", "1e-3"])
     def test_operation_single_arg(self, parse_input_mocked_metadata, arg):
         """Test that an operation with one argument is correctly parsed"""
         bb = parse_input_mocked_metadata("Coherent({}) | 0\n".format(arg))
-        assert bb.operations == [{'modes': [0], 'op': 'Coherent', 'args': [complex(arg)], 'kwargs': {}}]
+        assert bb.operations == [
+            {"modes": [0], "op": "Coherent", "args": [complex(arg)], "kwargs": {}}
+        ]
 
     def test_operation_multiple_arg(self, parse_input_mocked_metadata):
         """Test that an operation with multiple arguments is correctly parsed"""
         bb = parse_input_mocked_metadata("Coherent(-0.3+2j, 0, 1e-3) | 0\n")
-        assert bb.operations == [{'modes': [0], 'op': 'Coherent', 'args': [-0.3+2j, 0, 1e-3], 'kwargs': {}}]
+        assert bb.operations == [
+            {"modes": [0], "op": "Coherent", "args": [-0.3 + 2j, 0, 1e-3], "kwargs": {}}
+        ]
 
     def test_operation_kwarg(self, parse_input_mocked_metadata):
         """Test that an operation with keyword arguments is correctly parsed"""
         bb = parse_input_mocked_metadata("Coherent(alpha=-0.3+2j) | 0\n")
-        assert bb.operations == [{'modes': [0], 'op': 'Coherent', 'args': [], 'kwargs': {'alpha':-0.3+2j}}]
+        assert bb.operations == [
+            {"modes": [0], "op": "Coherent", "args": [], "kwargs": {"alpha": -0.3 + 2j}}
+        ]
 
     def test_operation_multiple_kwarg(self, parse_input_mocked_metadata):
         """Test that an operation with multiple keyword arguments is correctly parsed"""
         bb = parse_input_mocked_metadata("MeasureHomodyne(phi=0.23, b=1) | 0\n")
-        assert bb.operations == [{'modes': [0], 'op': 'MeasureHomodyne', 'args': [], 'kwargs': {'phi':0.23, 'b':1}}]
+        assert bb.operations == [
+            {"modes": [0], "op": "MeasureHomodyne", "args": [], "kwargs": {"phi": 0.23, "b": 1}}
+        ]
 
     # @pytest.mark.skip()
     # def test_operation_args_and_kwarg(self, parse_input):
@@ -244,18 +270,20 @@ class TestParsingQuantumPrograms:
 
     def test_operation_arg_expressions(self, parse_input_mocked_metadata):
         """Test that expressions inside arguments are properly evaluated"""
-        bb = parse_input_mocked_metadata("float alpha = 0.5\nfloat Delta=sqrt(2)\nCoherent(alpha**2.0, Delta*sqrt(pi), 0.2*10) | 0\n")
+        bb = parse_input_mocked_metadata(
+            "float alpha = 0.5\nfloat Delta=sqrt(2)\nCoherent(alpha**2.0, Delta*sqrt(pi), 0.2*10) | 0\n"
+        )
 
         alpha = 0.5
         Delta = np.sqrt(2)
-        expected = [alpha**2, Delta*np.sqrt(np.pi), 0.2*10]
+        expected = [alpha ** 2, Delta * np.sqrt(np.pi), 0.2 * 10]
 
-        assert bb.operations == [{'modes': [0], 'op': 'Coherent', 'args': expected, 'kwargs': {}}]
+        assert bb.operations == [{"modes": [0], "op": "Coherent", "args": expected, "kwargs": {}}]
 
     def test_operation_arg_array(self, parse_input_mocked_metadata):
         """Test that arrays inside arguments are properly evaluated"""
         bb = parse_input_mocked_metadata("float array A =\n\t1, 5\nGaussian(means=A) | 0\n")
-        assert np.all(bb.operations[0]['kwargs']['means'] == np.array([[1, 5]]))
+        assert np.all(bb.operations[0]["kwargs"]["means"] == np.array([[1, 5]]))
 
 
 class TestParsingMetadata:
@@ -264,12 +292,17 @@ class TestParsingMetadata:
     def test_target_name(self, parse_input):
         """Test that device name is extracted"""
         bb = parse_input("name testname\nversion 1.0\ntarget example")
-        assert bb.target['name'] == "example"
+        assert bb.target["name"] == "example"
 
-    def test_device_kwarg(self, parse_input):
+    def test_target_kwarg(self, parse_input):
         """Test that an device with keyword arguments is correctly parsed"""
         bb = parse_input("name testname\nversion 1.0\ntarget example (shots=10, hbar=0.2)")
-        assert bb.target['options'] == {"shots": 10, "hbar": 0.2}
+        assert bb.target["options"] == {"shots": 10, "hbar": 0.2}
+
+    def test_target_arg(self, parse_input):
+        """Test that an device with positional arguments raises a warning"""
+        with pytest.warns(SyntaxWarning, match="only accept keyword options"):
+            parse_input("name testname\nversion 1.0\ntarget example (6)")
 
 
 class TestRegRefTransform:
@@ -277,9 +310,9 @@ class TestRegRefTransform:
 
     def test_initialize(self):
         """Test initialization using a SymPy function"""
-        q0 = sym.Symbol('q0')
-        q2 = sym.Symbol('q2')
-        f = (q0-q2)/np.sqrt(2)
+        q0 = sym.Symbol("q0")
+        q2 = sym.Symbol("q2")
+        f = (q0 - q2) / np.sqrt(2)
 
         rrt = RegRefTransform(f)
 
@@ -287,7 +320,7 @@ class TestRegRefTransform:
         assert set(rrt.regrefs) == {0, 2}
 
         if rrt.regrefs == [0, 2]:
-            assert np.allclose(rrt.func(0.543, -0.432), (0.543+0.432)/np.sqrt(2))
+            assert np.allclose(rrt.func(0.543, -0.432), (0.543 + 0.432) / np.sqrt(2))
 
         # Note: the order in which SymPy returns the variables of a symbolic function are
         # stochastic and may change at runtime. In this particular case, sometimes it returns
@@ -297,13 +330,13 @@ class TestRegRefTransform:
         # correct order to apply the register arguments, but must be taken into account
         # during test assertions.
         if rrt.regrefs == [2, 0]:
-            assert np.allclose(rrt.func(0.543, -0.432), (-0.432-0.543)/np.sqrt(2))
+            assert np.allclose(rrt.func(0.543, -0.432), (-0.432 - 0.543) / np.sqrt(2))
 
     def test_str(self):
         """Test string representation of a RegRefTransform"""
-        q0 = sym.Symbol('q0')
-        q2 = sym.Symbol('q2')
-        f = (q0+q2)/np.sqrt(2)
+        q0 = sym.Symbol("q0")
+        q2 = sym.Symbol("q2")
+        f = (q0 + q2) / np.sqrt(2)
 
         rrt = RegRefTransform(f)
 
@@ -316,22 +349,22 @@ class TestParseFunction:
     @pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python >=3.6")
     def test_parse_file(self, tmpdir):
         """Test that device name is extracted"""
-        filename = tmpdir.join('test.xbb')
+        filename = tmpdir.join("test.xbb")
 
-        with open(filename, 'w') as f:
+        with open(filename, "w") as f:
             f.write(test_file)
 
         bb = parse(antlr4.FileStream(filename))
 
         assert bb._var == {"alpha": 0.3423}
 
-        expected = {"name": 'fock', 'options': {'num_subsystems':1, 'cutoff_dim':7, 'shots':10}}
+        expected = {"name": "fock", "options": {"num_subsystems": 1, "cutoff_dim": 7, "shots": 10}}
         assert bb.target == expected
 
         expected = [
-            {'op': 'Coherent', 'args': [0.3423, np.sqrt(np.pi)], 'kwargs':{}, 'modes': [0]},
-            {'op': 'MeasureFock', 'args': [], 'kwargs':{}, 'modes': [0]}
-            ]
+            {"op": "Coherent", "args": [0.3423, np.sqrt(np.pi)], "kwargs": {}, "modes": [0]},
+            {"op": "MeasureFock", "args": [], "kwargs": {}, "modes": [0]},
+        ]
 
         assert bb.operations == expected
 
@@ -341,12 +374,12 @@ class TestParseFunction:
 
         assert bb._var == {"alpha": 0.3423}
 
-        expected = {"name": 'fock', 'options': {'num_subsystems':1, 'cutoff_dim':7, 'shots':10}}
+        expected = {"name": "fock", "options": {"num_subsystems": 1, "cutoff_dim": 7, "shots": 10}}
         assert bb.target == expected
 
         expected = [
-            {'op': 'Coherent', 'args': [0.3423, np.sqrt(np.pi)], 'kwargs':{}, 'modes': [0]},
-            {'op': 'MeasureFock', 'args': [], 'kwargs':{}, 'modes': [0]}
-            ]
+            {"op": "Coherent", "args": [0.3423, np.sqrt(np.pi)], "kwargs": {}, "modes": [0]},
+            {"op": "MeasureFock", "args": [], "kwargs": {}, "modes": [0]},
+        ]
 
         assert bb.operations == expected

--- a/blackbird_python/blackbird/tests/test_load_dump.py
+++ b/blackbird_python/blackbird/tests/test_load_dump.py
@@ -101,6 +101,7 @@ def test_dump(tmpdir):
     assert res == expected
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="dictionary ordering is stochastic")
 def test_dumps(tmpdir):
     """Test that a Blackbird script is serialized to a string"""
     bb = loads(test_script)

--- a/blackbird_python/blackbird/tests/test_load_dump.py
+++ b/blackbird_python/blackbird/tests/test_load_dump.py
@@ -37,22 +37,22 @@ MeasureFock() | 0
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python >=3.6")
 def test_load(tmpdir):
     """Test that a Blackbird script is deserialized from a file"""
-    filename = tmpdir.join('test.xbb')
+    filename = tmpdir.join("test.xbb")
 
-    with open(filename, 'w') as f:
+    with open(filename, "w") as f:
         f.write(test_script)
 
     bb = load(filename)
 
     assert bb._var == {"alpha": 0.3423}
 
-    expected = {"name": 'fock', 'options': {'num_subsystems':1, 'cutoff_dim':7, 'shots':10}}
+    expected = {"name": "fock", "options": {"num_subsystems": 1, "cutoff_dim": 7, "shots": 10}}
     assert bb.target == expected
 
     expected = [
-        {'op': 'Coherent', 'args': [0.3423, np.sqrt(np.pi)], 'kwargs':{}, 'modes': [0]},
-        {'op': 'MeasureFock', 'args': [], 'kwargs':{}, 'modes': [0]}
-        ]
+        {"op": "Coherent", "args": [0.3423, np.sqrt(np.pi)], "kwargs": {}, "modes": [0]},
+        {"op": "MeasureFock", "args": [], "kwargs": {}, "modes": [0]},
+    ]
 
     assert bb.operations == expected
 
@@ -63,13 +63,13 @@ def test_loads():
 
     assert bb._var == {"alpha": 0.3423}
 
-    expected = {"name": 'fock', 'options': {'num_subsystems':1, 'cutoff_dim':7, 'shots':10}}
+    expected = {"name": "fock", "options": {"num_subsystems": 1, "cutoff_dim": 7, "shots": 10}}
     assert bb.target == expected
 
     expected = [
-        {'op': 'Coherent', 'args': [0.3423, np.sqrt(np.pi)], 'kwargs':{}, 'modes': [0]},
-        {'op': 'MeasureFock', 'args': [], 'kwargs':{}, 'modes': [0]}
-        ]
+        {"op": "Coherent", "args": [0.3423, np.sqrt(np.pi)], "kwargs": {}, "modes": [0]},
+        {"op": "MeasureFock", "args": [], "kwargs": {}, "modes": [0]},
+    ]
 
     assert bb.operations == expected
 
@@ -78,13 +78,13 @@ def test_loads():
 def test_dump(tmpdir):
     """Test that a Blackbird script is serialized to a file"""
     bb = loads(test_script)
-    filename = tmpdir.join('test.xbb')
+    filename = tmpdir.join("test.xbb")
 
-    with open(filename, 'w') as f:
+    with open(filename, "w") as f:
         dump(bb, f)
 
     # read from file
-    with open(filename, 'r') as f:
+    with open(filename, "r") as f:
         res = "".join(f.readlines())
 
     expected = dedent(
@@ -95,7 +95,9 @@ def test_dump(tmpdir):
 
         Coherent(0.3423, {}) | 0
         MeasureFock() | 0
-        """.format(np.sqrt(np.pi))
+        """.format(
+            np.sqrt(np.pi)
+        )
     )
 
     assert res == expected
@@ -115,7 +117,9 @@ def test_dumps(tmpdir):
 
         Coherent(0.3423, {}) | 0
         MeasureFock() | 0
-        """.format(np.sqrt(np.pi))
+        """.format(
+            np.sqrt(np.pi)
+        )
     )
 
     assert res == expected

--- a/blackbird_python/blackbird/tests/test_load_dump.py
+++ b/blackbird_python/blackbird/tests/test_load_dump.py
@@ -1,0 +1,120 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the load(s) and dump(s) functions"""
+import sys
+from textwrap import dedent
+
+import pytest
+
+import numpy as np
+
+from blackbird import load, loads, dump, dumps
+
+
+test_script = """
+# a test blackbird script
+name test_name
+version 1.0
+target fock (num_subsystems=1, cutoff_dim=7, shots=10)
+
+float alpha = 0.3423
+Coherent(alpha, sqrt(pi)) | 0
+MeasureFock() | 0
+"""
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python >=3.6")
+def test_load( tmpdir):
+    """Test that a Blackbird script is deserialized from a file"""
+    filename = tmpdir.join('test.xbb')
+
+    with open(filename, 'w') as f:
+        f.write(test_script)
+
+    bb = load(filename)
+
+    assert bb._var == {"alpha": 0.3423}
+
+    expected = {"name": 'fock', 'options': {'num_subsystems':1, 'cutoff_dim':7, 'shots':10}}
+    assert bb.target == expected
+
+    expected = [
+        {'op': 'Coherent', 'args': [0.3423, np.sqrt(np.pi)], 'kwargs':{}, 'modes': [0]},
+        {'op': 'MeasureFock', 'args': [], 'kwargs':{}, 'modes': [0]}
+        ]
+
+    assert bb.operations == expected
+
+
+def test_loads():
+    """Test that a Blackbird script is deserialized from a string"""
+    bb = loads(test_script)
+
+    assert bb._var == {"alpha": 0.3423}
+
+    expected = {"name": 'fock', 'options': {'num_subsystems':1, 'cutoff_dim':7, 'shots':10}}
+    assert bb.target == expected
+
+    expected = [
+        {'op': 'Coherent', 'args': [0.3423, np.sqrt(np.pi)], 'kwargs':{}, 'modes': [0]},
+        {'op': 'MeasureFock', 'args': [], 'kwargs':{}, 'modes': [0]}
+        ]
+
+    assert bb.operations == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python >=3.6")
+def test_dump(tmpdir):
+    """Test that a Blackbird script is serialized to a file"""
+    bb = loads(test_script)
+    filename = tmpdir.join('test.xbb')
+
+    with open(filename, 'w') as f:
+        dump(bb, f)
+
+    # read from file
+    with open(filename, 'r') as f:
+        res = "".join(f.readlines())
+
+    expected = dedent(
+        """\
+        name test_name
+        version 1.0
+        target fock (num_subsystems=1, cutoff_dim=7, shots=10)
+
+        Coherent(0.3423, {}) | 0
+        MeasureFock() | 0
+        """.format(np.sqrt(np.pi))
+    )
+
+    assert res == expected
+
+
+def test_dumps(tmpdir):
+    """Test that a Blackbird script is serialized to a string"""
+    bb = loads(test_script)
+    res = dumps(bb)
+
+    expected = dedent(
+        """\
+        name test_name
+        version 1.0
+        target fock (num_subsystems=1, cutoff_dim=7, shots=10)
+
+        Coherent(0.3423, {}) | 0
+        MeasureFock() | 0
+        """.format(np.sqrt(np.pi))
+    )
+
+    assert res == expected

--- a/blackbird_python/blackbird/tests/test_load_dump.py
+++ b/blackbird_python/blackbird/tests/test_load_dump.py
@@ -35,7 +35,7 @@ MeasureFock() | 0
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python >=3.6")
-def test_load( tmpdir):
+def test_load(tmpdir):
     """Test that a Blackbird script is deserialized from a file"""
     filename = tmpdir.join('test.xbb')
 

--- a/blackbird_python/blackbird/tests/test_program.py
+++ b/blackbird_python/blackbird/tests/test_program.py
@@ -175,7 +175,7 @@ class TestBlackbirdProgram:
                 "op": "Dgate",
                 "modes": [0],
                 "args": [],
-                "kwargs": {"alpha": 0.43 - 0.543j, "phi": 0.54},
+                "kwargs": OrderedDict([("alpha", 0.43 - 0.543j), ("phi", 0.54)]),
             }
         )
         res = bb.serialize()
@@ -316,7 +316,6 @@ class TestBlackbirdProgram:
         )
 
         res = bb.serialize()
-        print(res)
         expected = dedent(
             """\
             name prog

--- a/blackbird_python/blackbird/tests/test_program.py
+++ b/blackbird_python/blackbird/tests/test_program.py
@@ -30,9 +30,7 @@ class TestNumPyToBlackbird:
         """Test real array is correctly formatted"""
         A = np.array([[0.453, 1, 0.213], [-0.543, 1.342, 1e-4]])
         res = "\n".join(numpy_to_blackbird(A, "A"))
-        expected = (
-            "float array A[2, 3] =\n    0.453, 1.0, 0.213\n    -0.543, 1.342, 0.0001\n"
-        )
+        expected = "float array A[2, 3] =\n    0.453, 1.0, 0.213\n    -0.543, 1.342, 0.0001\n"
         assert res == expected
 
     def test_int_array(self):
@@ -44,9 +42,7 @@ class TestNumPyToBlackbird:
 
     def test_complex_array(self):
         """Test complex array is correctly formatted"""
-        A = np.array(
-            [[0.453 - 0.543j, 1, 0.213 + 8j], [-0.543j, 1.342 + 0.5j, 1e-4 - 2e2j]]
-        )
+        A = np.array([[0.453 - 0.543j, 1, 0.213 + 8j], [-0.543j, 1.342 + 0.5j, 1e-4 - 2e2j]])
         res = "\n".join(numpy_to_blackbird(A, "A"))
         expected = dedent(
             """\
@@ -56,6 +52,13 @@ class TestNumPyToBlackbird:
             """
         )
         assert res == expected
+
+    def test_unknown_array(self):
+        """Test non-numeric array raises an exception"""
+        A = np.array([True, False])
+
+        with pytest.raises(ValueError, match="unsupported type"):
+            numpy_to_blackbird(A, "A")
 
 
 class TestBlackbirdProgram:
@@ -119,9 +122,7 @@ class TestBlackbirdProgram:
     def test_serialize_operation_args(self):
         """Test serialization of an operation with 1 arg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
-        bb._operations.append(
-            {"op": "Dgate", "modes": [0], "args": [0.43 - 0.543j], "kwargs": {}}
-        )
+        bb._operations.append({"op": "Dgate", "modes": [0], "args": [0.43 - 0.543j], "kwargs": {}})
         res = bb.serialize()
         expected = dedent(
             """\
@@ -136,9 +137,7 @@ class TestBlackbirdProgram:
     def test_serialize_operation_multiple_args(self):
         """Test serialization of an operation with many args"""
         bb = BlackbirdProgram(name="prog", version=1.0)
-        bb._operations.append(
-            {"op": "Sgate", "modes": [0], "args": [0.43, 0.5432], "kwargs": {}}
-        )
+        bb._operations.append({"op": "Sgate", "modes": [0], "args": [0.43, 0.5432], "kwargs": {}})
         res = bb.serialize()
         expected = dedent(
             """\
@@ -201,9 +200,7 @@ class TestBlackbirdProgram:
             }
         )
 
-        with pytest.raises(
-            ValueError, match="contain both positional and keyword arguments"
-        ):
+        with pytest.raises(ValueError, match="contain both positional and keyword arguments"):
             bb.serialize()
 
     def test_serialize_operation_multimode(self):
@@ -224,11 +221,9 @@ class TestBlackbirdProgram:
     def test_serialize_operation_array_arg(self):
         """Test serialization of an operation with an array arg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
-        U = np.identity(2)
+        U = np.int64(np.identity(2))
 
-        bb._operations.append(
-            {"op": "Interferometer", "modes": [0], "args": [U], "kwargs": {}}
-        )
+        bb._operations.append({"op": "Interferometer", "modes": [0], "args": [U], "kwargs": {}})
 
         res = bb.serialize()
         expected = dedent(
@@ -248,7 +243,7 @@ class TestBlackbirdProgram:
     def test_serialize_operation_array_kwarg(self):
         """Test serialization of an operation with an array kwarg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
-        U = np.identity(2)
+        U = np.int64(np.identity(2))
 
         bb._operations.append(
             {"op": "Interferometer", "modes": [0], "args": [], "kwargs": {"U": U}}
@@ -287,9 +282,7 @@ class TestBlackbirdProgram:
     def test_serialize_operation_string_kwarg(self):
         """Test serialization of an operation with a string kwarg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
-        bb._operations.append(
-            {"op": "Dgate", "modes": [0], "args": [], "kwargs": {"key": "val"}}
-        )
+        bb._operations.append({"op": "Dgate", "modes": [0], "args": [], "kwargs": {"key": "val"}})
         res = bb.serialize()
         expected = dedent(
             """\
@@ -304,7 +297,7 @@ class TestBlackbirdProgram:
     def test_serialize_operation_multiple_arrays(self):
         """Test serialization of an operation with multiple array args"""
         bb = BlackbirdProgram(name="prog", version=1.0)
-        U = np.identity(2)
+        U = np.int64(np.identity(2))
         U2 = np.array([[1, 2j], [-2j, 3]])
 
         bb._operations.extend(

--- a/blackbird_python/blackbird/tests/test_program.py
+++ b/blackbird_python/blackbird/tests/test_program.py
@@ -1,0 +1,334 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the program module"""
+import pytest
+from textwrap import dedent
+
+import numpy as np
+
+from blackbird.program import BlackbirdProgram, numpy_to_blackbird
+
+
+class TestNumPyToBlackbird:
+    """Tests for the NumPy to Blackbird function"""
+
+    def test_real_array(self):
+        """Test real array is correctly formatted"""
+        A = np.array([[0.453, 1, 0.213], [-0.543, 1.342, 1e-4]])
+        res = "\n".join(numpy_to_blackbird(A, "A"))
+        expected = (
+            "float array A[2, 3] =\n    0.453, 1.0, 0.213\n    -0.543, 1.342, 0.0001\n"
+        )
+        assert res == expected
+
+    def test_int_array(self):
+        """Test integer array is correctly formatted"""
+        A = np.array([[1, -0, -15]])
+        res = "\n".join(numpy_to_blackbird(A, "A"))
+        expected = "int array A[1, 3] =\n    1, 0, -15\n"
+        assert res == expected
+
+    def test_complex_array(self):
+        """Test complex array is correctly formatted"""
+        A = np.array(
+            [[0.453 - 0.543j, 1, 0.213 + 8j], [-0.543j, 1.342 + 0.5j, 1e-4 - 2e2j]]
+        )
+        res = "\n".join(numpy_to_blackbird(A, "A"))
+        expected = dedent(
+            """\
+            complex array A[2, 3] =
+                0.453-0.543j, 1.0+0.0j, 0.213+8.0j
+                -0.0-0.543j, 1.342+0.5j, 0.0001-200.0j
+            """
+        )
+        assert res == expected
+
+
+class TestBlackbirdProgram:
+    """Basic unit tests for the program class"""
+
+    def test_initialization(self):
+        """Test all attributes correctly initialized"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        assert not bb._var
+
+        assert bb.name == "prog"
+        assert bb.version == 1.0
+        assert not bb.modes
+
+        assert bb.target["name"] is None
+        assert not bb.target["options"]
+        assert not bb.operations
+
+        assert not len(bb)
+
+    def test_serialize_empty(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        res = bb.serialize()
+        assert res == "name prog\nversion 1.0\n"
+
+    def test_serialize_target(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._target["name"] = "chip0"
+        res = bb.serialize()
+        assert res == "name prog\nversion 1.0\ntarget chip0\n"
+
+        bb._target["options"] = {"shots": 100, "hbar": 0.2, "real": True, "str": "hi"}
+        res = bb.serialize()
+        assert res == dedent(
+            """\
+            name prog
+            version 1.0
+            target chip0 (shots=100, hbar=0.2, real=True, str="hi")
+            """
+        )
+
+    def test_serialize_operation_no_args(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._operations.append({"op": "Vac", "modes": [0]})
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            Vac | 0
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_args(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._operations.append(
+            {"op": "Dgate", "modes": [0], "args": [0.43 - 0.543j], "kwargs": {}}
+        )
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            Dgate(0.43-0.543j) | 0
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_multiple_args(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._operations.append(
+            {"op": "Sgate", "modes": [0], "args": [0.43, 0.5432], "kwargs": {}}
+        )
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            Sgate(0.43, 0.5432) | 0
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_kwargs(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._operations.append(
+            {"op": "MeasureFock", "modes": [0], "args": [], "kwargs": {"select": 2}}
+        )
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            MeasureFock(select=2) | 0
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_multiple_kwargs(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._operations.append(
+            {
+                "op": "Dgate",
+                "modes": [0],
+                "args": [],
+                "kwargs": {"alpha": 0.43 - 0.543j, "phi": 0.54},
+            }
+        )
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            Dgate(alpha=0.43-0.543j, phi=0.54) | 0
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_args_kwargs(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._operations.append(
+            {
+                "op": "Dgate",
+                "modes": [0],
+                "args": [0.54],
+                "kwargs": {"alpha": 0.43 - 0.543j, "phi": 0.54},
+            }
+        )
+
+        with pytest.raises(
+            ValueError, match="contain both positional and keyword arguments"
+        ):
+            bb.serialize()
+
+    def test_serialize_operation_multimode(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._operations.append({"op": "Vac", "modes": [0, 1, 2]})
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            Vac | [0, 1, 2]
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_array_arg(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        U = np.identity(2)
+
+        bb._operations.append(
+            {"op": "Interferometer", "modes": [0], "args": [U], "kwargs": {}}
+        )
+
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            int array A0[2, 2] =
+                1, 0
+                0, 1
+
+            Interferometer(A0) | 0
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_array_kwarg(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        U = np.identity(2)
+
+        bb._operations.append(
+            {"op": "Interferometer", "modes": [0], "args": [], "kwargs": {"U": U}}
+        )
+
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            int array A0[2, 2] =
+                1, 0
+                0, 1
+
+            Interferometer(U=A0) | 0
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_string_arg(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._operations.append({"op": "Dgate", "modes": [0], "args": ["hi"], "kwargs": {}})
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            Dgate("hi") | 0
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_string_kwarg(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        bb._operations.append(
+            {"op": "Dgate", "modes": [0], "args": [], "kwargs": {"key": "val"}}
+        )
+        res = bb.serialize()
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            Dgate(key="val") | 0
+            """
+        )
+        assert res == expected
+
+    def test_serialize_operation_multiple_arrays(self):
+        """Test serialization of an empty program"""
+        bb = BlackbirdProgram(name="prog", version=1.0)
+        U = np.identity(2)
+        U2 = np.array([[1, 2j], [-2j, 3]])
+
+        bb._operations.extend(
+            [
+                {"op": "Interferometer", "modes": [0, 2], "args": [U], "kwargs": {}},
+                {"op": "BSgate", "modes": [0, 1], "args": [0.543, -0.1231], "kwargs": {}},
+                {"op": "GaussianTransform", "modes": [0, 2], "args": [U2], "kwargs": {}},
+            ]
+        )
+
+        res = bb.serialize()
+        print(res)
+        expected = dedent(
+            """\
+            name prog
+            version 1.0
+
+            int array A0[2, 2] =
+                1, 0
+                0, 1
+
+            complex array A1[2, 2] =
+                1.0+0.0j, 0.0+2.0j
+                -0.0-2.0j, 3.0+0.0j
+
+            Interferometer(A0) | [0, 2]
+            BSgate(0.543, -0.1231) | [0, 1]
+            GaussianTransform(A1) | [0, 2]
+            """
+        )
+        assert res == expected

--- a/blackbird_python/blackbird/tests/test_program.py
+++ b/blackbird_python/blackbird/tests/test_program.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 """Tests for the program module"""
-import pytest
 from textwrap import dedent
+from collections import OrderedDict
+
+import pytest
 
 import numpy as np
 
@@ -81,13 +83,15 @@ class TestBlackbirdProgram:
         assert res == "name prog\nversion 1.0\n"
 
     def test_serialize_target(self):
-        """Test serialization of an empty program"""
+        """Test target serialization"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._target["name"] = "chip0"
         res = bb.serialize()
         assert res == "name prog\nversion 1.0\ntarget chip0\n"
 
-        bb._target["options"] = {"shots": 100, "hbar": 0.2, "real": True, "str": "hi"}
+        bb._target["options"] = OrderedDict(
+            [("shots", 100), ("hbar", 0.2), ("real", True), ("str", "hi")]
+        )
         res = bb.serialize()
         assert res == dedent(
             """\
@@ -98,7 +102,7 @@ class TestBlackbirdProgram:
         )
 
     def test_serialize_operation_no_args(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with no args"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._operations.append({"op": "Vac", "modes": [0]})
         res = bb.serialize()
@@ -113,7 +117,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_args(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with 1 arg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._operations.append(
             {"op": "Dgate", "modes": [0], "args": [0.43 - 0.543j], "kwargs": {}}
@@ -130,7 +134,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_multiple_args(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with many args"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._operations.append(
             {"op": "Sgate", "modes": [0], "args": [0.43, 0.5432], "kwargs": {}}
@@ -147,7 +151,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_kwargs(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with a kwarg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._operations.append(
             {"op": "MeasureFock", "modes": [0], "args": [], "kwargs": {"select": 2}}
@@ -164,7 +168,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_multiple_kwargs(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with many kwargs"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._operations.append(
             {
@@ -186,7 +190,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_args_kwargs(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with args and kwargs raises an error"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._operations.append(
             {
@@ -203,7 +207,7 @@ class TestBlackbirdProgram:
             bb.serialize()
 
     def test_serialize_operation_multimode(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation on multiple modes"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._operations.append({"op": "Vac", "modes": [0, 1, 2]})
         res = bb.serialize()
@@ -218,7 +222,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_array_arg(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with an array arg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         U = np.identity(2)
 
@@ -242,7 +246,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_array_kwarg(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with an array kwarg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         U = np.identity(2)
 
@@ -266,7 +270,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_string_arg(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with a string arg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._operations.append({"op": "Dgate", "modes": [0], "args": ["hi"], "kwargs": {}})
         res = bb.serialize()
@@ -281,7 +285,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_string_kwarg(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with a string kwarg"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         bb._operations.append(
             {"op": "Dgate", "modes": [0], "args": [], "kwargs": {"key": "val"}}
@@ -298,7 +302,7 @@ class TestBlackbirdProgram:
         assert res == expected
 
     def test_serialize_operation_multiple_arrays(self):
-        """Test serialization of an empty program"""
+        """Test serialization of an operation with multiple array args"""
         bb = BlackbirdProgram(name="prog", version=1.0)
         U = np.identity(2)
         U2 = np.array([[1, 2j], [-2j, 3]])

--- a/doc/blackbird_python/program.rst
+++ b/doc/blackbird_python/program.rst
@@ -1,0 +1,4 @@
+.. automodule:: blackbird.program
+   :members:
+   :private-members:
+   :special-members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -86,6 +86,7 @@ Blackbird is **free** and **open source**, released under the Apache License, Ve
 
    blackbird_python/init
    blackbird_python/installing
+   blackbird_python/program
    blackbird_python/listener
    blackbird_python/auxiliary
    blackbird_python/error


### PR DESCRIPTION
This PR adds several things to the Blackbird library:

1. A new `BlackbirdProgram` class, to encapsulate a blackbird program using Python data structures. The blackbird parser now automatically returns a `BlackbirdProgram` object. This is useful for several reasons:

   * It standardizes how the Blackbird data is represented in Python, and is much easier
     to document in Sphinx.

   * It allows us to return an object with properties and methods that provide useful information to the developer/user.

2. A `BlackbirdProgram.serialize()` method has been added, allowing a loaded/parsed blackbird program to be re-serialized. This can be used by any library that needs to send or save blackbird data, i.e. Strawberry Fields/backends.

3. Top level `load`, `loads`, `dump`, and `dumps` functions have been added, for serializing/deserializing Blackbird program to a file/string. This terminology matches that used for the standard Python JSON library, and also uses the same function signatures, allowing it to almost be a drop in replacement for users familiar with Python JSON.