### PR TITLE
Converted version number to a string

### DIFF
--- a/blackbird_python/blackbird/program.py
+++ b/blackbird_python/blackbird/program.py
@@ -86,7 +86,7 @@ def numpy_to_blackbird(A, var_name):
 class BlackbirdProgram:
     """Python representation of a Blackbird program."""
 
-    def __init__(self, name="blackbird_program", version=1.0):
+    def __init__(self, name="blackbird_program", version="1.0"):
         self._var = {}
         self._modes = set()
 
@@ -110,7 +110,7 @@ class BlackbirdProgram:
         """Version of the Blackbird parser the program targets
 
         Returns:
-            float: version number
+            str: version number
         """
         return self._version
 

--- a/blackbird_python/blackbird/tests/test_listener.py
+++ b/blackbird_python/blackbird/tests/test_listener.py
@@ -289,6 +289,19 @@ class TestParsingQuantumPrograms:
 class TestParsingMetadata:
     """Tests for parsing quantum devices"""
 
+    def test_name(self, parse_input):
+        """Test that device name is extracted"""
+        bb = parse_input("name testname\nversion 1.0")
+        assert bb.name == "testname"
+
+    def test_version(self, parse_input):
+        """Test that device name is extracted"""
+        bb = parse_input("name testname\nversion 1.0")
+        assert bb.version == "1.0"
+
+        bb = parse_input("name testname\nversion 1.12")
+        assert bb.version == "1.12"
+
     def test_target_name(self, parse_input):
         """Test that device name is extracted"""
         bb = parse_input("name testname\nversion 1.0\ntarget example")


### PR DESCRIPTION
As @smite noticed, the version number should be a string, not a float. Updated in this PR (and two tests added).