### PR TITLE
Remove NumPy dependence from Blackbird

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - LOGGING=info
 install:
   - pip install -r requirements.txt --upgrade
-  - pip install wheel pytest pytest-cov codecov --upgrade
+  - pip install wheel numpy pytest pytest-cov codecov --upgrade
   - pip install -e .
 script:
   - make coverage

--- a/blackbird_python/blackbird/tests/test_program.py
+++ b/blackbird_python/blackbird/tests/test_program.py
@@ -21,7 +21,7 @@ import pytest
 import numpy as np
 import sympy as sym
 
-from blackbird.program import BlackbirdProgram, numpy_to_blackbird
+from blackbird.program import BlackbirdProgram, list_to_blackbird
 
 
 class TestNumPyToBlackbird:
@@ -29,22 +29,22 @@ class TestNumPyToBlackbird:
 
     def test_real_array(self):
         """Test real array is correctly formatted"""
-        A = np.array([[0.453, 1, 0.213], [-0.543, 1.342, 1e-4]])
-        res = "\n".join(numpy_to_blackbird(A, "A"))
+        A = [[0.453, 1, 0.213], [-0.543, 1.342, 1e-4]]
+        res = "\n".join(list_to_blackbird(A, "A"))
         expected = "float array A[2, 3] =\n    0.453, 1.0, 0.213\n    -0.543, 1.342, 0.0001\n"
         assert res == expected
 
     def test_int_array(self):
         """Test integer array is correctly formatted"""
-        A = np.array([[1, -0, -15]])
-        res = "\n".join(numpy_to_blackbird(A, "A"))
+        A = [[1, -0, -15]]
+        res = "\n".join(list_to_blackbird(A, "A"))
         expected = "int array A[1, 3] =\n    1, 0, -15\n"
         assert res == expected
 
     def test_complex_array(self):
         """Test complex array is correctly formatted"""
-        A = np.array([[0.453 - 0.543j, 1, 0.213 + 8j], [-0.543j, 1.342 + 0.5j, 1e-4 - 2e2j]])
-        res = "\n".join(numpy_to_blackbird(A, "A"))
+        A = [[0.453 - 0.543j, 1, 0.213 + 8j], [-0.543j, 1.342 + 0.5j, 1e-4 - 2e2j]]
+        res = "\n".join(list_to_blackbird(A, "A"))
         expected = dedent(
             """\
             complex array A[2, 3] =
@@ -56,10 +56,10 @@ class TestNumPyToBlackbird:
 
     def test_unknown_array(self):
         """Test non-numeric array raises an exception"""
-        A = np.array([True, False])
+        A = [True, False]
 
         with pytest.raises(ValueError, match="unsupported type"):
-            numpy_to_blackbird(A, "A")
+            list_to_blackbird(A, "A")
 
 
 class TestBlackbirdProgram:
@@ -185,6 +185,14 @@ class TestBlackbirdSerialize:
         )
         assert res == expected
 
+    def test_serialize_invalid_operation_args(self):
+        """Test serialization of an operation with invalid arg raises error"""
+        bb = BlackbirdProgram(name="prog", version=0.0)
+        bb._operations.append({"op": "Dgate", "modes": [0], "args": [np.array([0.5])], "kwargs": {}})
+
+        with pytest.raises(ValueError, match="Unknown argument type"):
+            res = bb.serialize()
+
     def test_serialize_operation_multiple_args(self):
         """Test serialization of an operation with many args"""
         bb = BlackbirdProgram(name="prog", version=0.0)
@@ -216,6 +224,14 @@ class TestBlackbirdSerialize:
             """
         )
         assert res == expected
+
+    def test_serialize_invalid_operation_kwargs(self):
+        """Test serialization of an operation with invalid arg raises error"""
+        bb = BlackbirdProgram(name="prog", version=0.0)
+        bb._operations.append({"op": "Dgate", "modes": [0], "args": [], "kwargs": {"U": np.array([0.5])}})
+
+        with pytest.raises(ValueError, match="Unknown argument type"):
+            res = bb.serialize()
 
     def test_serialize_operation_multiple_kwargs(self):
         """Test serialization of an operation with many kwargs"""
@@ -280,7 +296,7 @@ class TestBlackbirdSerialize:
     def test_serialize_operation_array_arg(self):
         """Test serialization of an operation with an array arg"""
         bb = BlackbirdProgram(name="prog", version=0.0)
-        U = np.int64(np.identity(2))
+        U = np.int64(np.identity(2)).tolist()
 
         bb._operations.append({"op": "Interferometer", "modes": [0], "args": [U], "kwargs": {}})
 
@@ -302,7 +318,7 @@ class TestBlackbirdSerialize:
     def test_serialize_operation_array_kwarg(self):
         """Test serialization of an operation with an array kwarg"""
         bb = BlackbirdProgram(name="prog", version=0.0)
-        U = np.int64(np.identity(2))
+        U = np.int64(np.identity(2)).tolist()
 
         bb._operations.append(
             {"op": "Interferometer", "modes": [0], "args": [], "kwargs": {"U": U}}
@@ -372,8 +388,8 @@ class TestBlackbirdSerialize:
     def test_serialize_operation_multiple_arrays(self):
         """Test serialization of an operation with multiple array args"""
         bb = BlackbirdProgram(name="prog", version=0.0)
-        U = np.int64(np.identity(2))
-        U2 = np.array([[1, 2j], [-2j, 3]])
+        U = np.int64(np.identity(2)).tolist()
+        U2 = np.array([[1, 2j], [-2j, 3]]).tolist()
 
         bb._operations.extend(
             [

--- a/blackbird_python/blackbird/utils.py
+++ b/blackbird_python/blackbird/utils.py
@@ -40,7 +40,6 @@ Code details
 """
 from collections import namedtuple
 
-import numpy as np
 import sympy as sym
 from sympy.solvers import solve
 
@@ -217,7 +216,7 @@ def match_template(template, program):
 
     for n1, n2 in GM.mapping.items():
         for x, y in zip(G1nodes[n1]['args'], G2nodes[n2]['args']):
-            if np.all(x != y):
+            if x != y:
                 if isinstance(x, sym.Symbol):
                     key = str(x)
                     val = y

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 antlr4-python3-runtime>=4.7.1
-numpy>=1.16
 sympy
 networkx

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ with open("blackbird_python/blackbird/_version.py") as f:
 	version = f.readlines()[-1].split()[-1].strip("\"'")
 
 requirements = [
-    "numpy>=1.16",
     "sympy",
     "antlr4-python3-runtime>=4.7.1",
     "networkx"


### PR DESCRIPTION
**Context:** on linux systems not supported under the `many_linux1` standard, pre-built NumPy wheels cannot be installed. Instead, NumPy has to be compiled by source, taking a significantly longer amount of time.

**Description:** NumPy is used as a convenience in the Blackbird parser, but there is no hard requirement to use NumPy. In this PR, use of NumPy in the Blackbird Python parser library is completely removed --- arrays are simply passed as standard Python nested lists.

**Benefits:** NumPy requirement is removed as per above.

**Drawbacks:** Just means that the parser has to do more 'from first principles'. Useful NumPy functions (such as np.all, etc.) can no longer be used, more list comprehensions required, and we must be smart about swapping between the `math` and `cmath` modules programmatically.

Also, the tests still depend on NumPy for now (just for convenience in creating the test data).

