### PR TITLE
Pin antlr4 to version 4.7.2

### DIFF
--- a/blackbird_python/blackbird/_version.py
+++ b/blackbird_python/blackbird/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-antlr4-python3-runtime>=4.7.1
+antlr4-python3-runtime==4.7.2
 sympy
 networkx

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("blackbird_python/blackbird/_version.py") as f:
 
 requirements = [
     "sympy",
-    "antlr4-python3-runtime>=4.7.1",
+    "antlr4-python3-runtime>=4.7.2",
     "networkx"
 ]
 


### PR DESCRIPTION
Pins the antlr4 python runtime to version 4.7.2, as the latest release of 4.8 causes breaking changes.