### PR TITLE
Undo the removal of NumPy as a dependence on Blackbird

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - LOGGING=info
 install:
   - pip install -r requirements.txt --upgrade
-  - pip install wheel numpy pytest pytest-cov codecov --upgrade
+  - pip install wheel pytest pytest-cov codecov --upgrade
   - pip install -e .
 script:
   - make coverage

--- a/blackbird_python/blackbird/_version.py
+++ b/blackbird_python/blackbird/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -33,6 +33,8 @@ Summary
 
 .. autosummary::
     PYTHON_TYPES
+    NUMPY_TYPES
+    RegRefTransform
     BlackbirdListener
     parse
 
@@ -45,6 +47,7 @@ import warnings
 
 import antlr4
 
+import numpy as np
 import sympy as sym
 
 from .blackbirdLexer import blackbirdLexer
@@ -53,11 +56,11 @@ from .blackbirdListener import blackbirdListener
 
 from .error import BlackbirdErrorListener, BlackbirdSyntaxError
 from .auxiliary import _expression, _get_arguments, _literal, _VAR, _PARAMS
-from .program import BlackbirdProgram, RegRefTransform
+from .program import BlackbirdProgram
 
 
 PYTHON_TYPES = {
-    "array": list,
+    "array": np.ndarray,
     "float": float,
     "complex": complex,
     "int": int,
@@ -66,6 +69,55 @@ PYTHON_TYPES = {
 }
 """dict[str->type]: Mapping from the allowed Blackbird types
 to the equivalent Python/NumPy types."""
+
+
+NUMPY_TYPES = {
+    "float": np.float64,
+    "complex": np.complex128,
+    "int": np.int64,
+    "str": np.str,
+    "bool": np.bool,
+}
+"""dict[str->type]: Mapping from the allowed Blackbird array types
+to the equivalent NumPy data types."""
+
+
+class RegRefTransform:
+    """Class to represent a classical register transform.
+
+    Args:
+        expr (sympy.Expr): a SymPy expression representing the RegRef transform
+    """
+
+    def __init__(self, expr):
+        """After initialization, the RegRefTransform has three attributes
+        which may be inspected to translate the Blackbird program to a
+        simulator or quantum hardware:
+
+        * :attr:`func`
+        * :attr:`regrefs`
+        * :attr:`func_str`
+        """
+        regref_symbols = list(expr.free_symbols)
+        # get the Python function represented by the regref transform
+        self.func = sym.lambdify(regref_symbols, expr)
+        """function: Scalar function that takes one or more values corresponding
+        to measurement results, and outputs a single numeric value."""
+
+        # get the regrefs involved
+        self.regrefs = [int(str(i)[1:]) for i in regref_symbols]
+        """list[int]: List of integers corresponding to the modes that are measured
+        and act as inputs to :attr:`func`. Note that the order of this list corresponds
+        to the order that the measured mode results should be passed to the function."""
+
+        self.func_str = str(expr)
+        """str: String representation of the RegRefTransform function."""
+
+    def __str__(self):
+        """Print formatting"""
+        return self.func_str
+
+    __repr__ = __str__
 
 
 class BlackbirdListener(blackbirdListener):
@@ -203,15 +255,17 @@ class BlackbirdListener(blackbirdListener):
             value = _literal(ctx.nonnumeric())
 
         try:
-            if isinstance(value, list):
-                # variable is an array
-                final_value = [[PYTHON_TYPES[vartype](el) for el in row] for row in value]
-            else:
-                final_value = PYTHON_TYPES[vartype](value)
-        except TypeError:
-            raise TypeError(
-                "Var {} = {} is not of declared type {}".format(name, value, vartype)
-            ) from None
+            # assume all variables are scalar
+            final_value = PYTHON_TYPES[vartype](value)
+        except:
+            try:
+                # maybe one of the variables was a NumPy array?
+                final_value = NUMPY_TYPES[vartype](value)
+            except:
+                # nope
+                raise TypeError(
+                    "Var {} = {} is not of declared type {}".format(name, value, vartype)
+                ) from None
 
         _VAR[name] = final_value
 
@@ -259,7 +313,7 @@ class BlackbirdListener(blackbirdListener):
                         value[-1].append(_expression(j))
 
         try:
-            final_value = [[PYTHON_TYPES[vartype](el) for el in row] for row in value]
+            final_value = np.array(value, dtype=NUMPY_TYPES[vartype])
         except:
             line = ctx.start.line
             col = ctx.start.column
@@ -270,7 +324,7 @@ class BlackbirdListener(blackbirdListener):
             )
 
         if shape is not None:
-            actual_shape = (len(final_value), len(final_value[0]))
+            actual_shape = final_value.shape
             if actual_shape != shape:
                 line = ctx.start.line
                 col = ctx.start.column

--- a/blackbird_python/blackbird/program.py
+++ b/blackbird_python/blackbird/program.py
@@ -30,104 +30,60 @@ Summary
 -------
 
 .. autosummary::
-    list_to_blackbird
-    RegRefTransform
+    numpy_to_blackbird
     BlackbirdProgram
 
 Code details
 ~~~~~~~~~~~~
 """
 import copy
-import numbers
 
+import numpy as np
 import sympy as sym
 
 
-def list_to_blackbird(A, var_name):
-    """Converts a Python nested list to a Blackbird script array type.
+def numpy_to_blackbird(A, var_name):
+    """Converts a numpy array to a Blackbird script array type.
 
     Args:
-        A (list[list]): 2-dimensional nested list
+        A (array): 2-dimensional NumPy array
         var_name (str): the array variable name
 
     Returns:
         list[str]: list containing each line representing the
             Blackbird array variable declaration
     """
-    if not isinstance(A[0], list):
-        A = [A]
 
-    shape = (len(A), len(A[0]))
-
-    if any(isinstance(el, bool) or not isinstance(el, numbers.Number) for row in A for el in row):
-        # unknown array type
-        raise ValueError("Array {} contains unsupported types".format(A))
-
-
-    elif any(isinstance(el, complex) for row in A for el in row):
+    if np.issubdtype(A.dtype, np.complexfloating):
         # complex array
-        script = ["complex array {}[{}, {}] =".format(var_name, *shape)]
+        script = ["complex array {}[{}, {}] =".format(var_name, *A.shape)]
         for row in A:
             row_str = "    " + ", ".join(
-                ["{0}{1}{2}j".format(float(n.real), "+-"[int(n.imag < 0)], float(abs(n.imag))) for n in row]
+                ["{0}{1}{2}j".format(n.real, "+-"[int(n.imag < 0)], abs(n.imag)) for n in row]
             )
             script.append(row_str)
 
-    elif any(isinstance(el, float) for row in A for el in row):
-        # real array
-        script = ["float array {}[{}, {}] =".format(var_name, *shape)]
-        for row in A:
-            row_str = "    " + ", ".join(["{}".format(float(n)) for n in row])
-            script.append(row_str)
-
-    elif all(isinstance(el, int) for row in A for el in row):
+    elif np.issubdtype(A.dtype, np.integer):
         # integer array
-        script = ["int array {}[{}, {}] =".format(var_name, *shape)]
+        script = ["int array {}[{}, {}] =".format(var_name, *A.shape)]
         for row in A:
             row_str = "    " + ", ".join(["{}".format(int(n)) for n in row])
             script.append(row_str)
 
+    elif np.issubdtype(A.dtype, np.floating):
+        # real array
+        script = ["float array {}[{}, {}] =".format(var_name, *A.shape)]
+        for row in A:
+            row_str = "    " + ", ".join(["{}".format(n) for n in row])
+            script.append(row_str)
+
+    else:
+        # unknown array type
+        raise ValueError("Array {} is of unsupported type {}".format(A, A.dtype))
+
     script.append("")
 
     return script
-
-
-class RegRefTransform:
-    """Class to represent a classical register transform.
-
-    Args:
-        expr (sympy.Expr): a SymPy expression representing the RegRef transform
-    """
-
-    def __init__(self, expr):
-        """After initialization, the RegRefTransform has three attributes
-        which may be inspected to translate the Blackbird program to a
-        simulator or quantum hardware:
-
-        * :attr:`func`
-        * :attr:`regrefs`
-        * :attr:`func_str`
-        """
-        regref_symbols = list(expr.free_symbols)
-        # get the Python function represented by the regref transform
-        self.func = sym.lambdify(regref_symbols, expr)
-        """function: Scalar function that takes one or more values corresponding
-        to measurement results, and outputs a single numeric value."""
-
-        # get the regrefs involved
-        self.regrefs = [int(str(i)[1:]) for i in regref_symbols]
-        """list[int]: List of integers corresponding to the modes that are measured
-        and act as inputs to :attr:`func`. Note that the order of this list corresponds
-        to the order that the measured mode results should be passed to the function."""
-
-        self.func_str = str(expr)
-        """str: String representation of the RegRefTransform function."""
-
-    def __str__(self):
-        """Print formatting"""
-        return self.func_str
-
-    __repr__ = __str__
 
 
 class BlackbirdProgram:
@@ -323,14 +279,14 @@ class BlackbirdProgram:
                 for v in op["args"]:
                     # for each operation argument, format it
                     # correctly depending on its type
-                    if isinstance(v, list):
+                    if isinstance(v, np.ndarray):
                         # create an array variable
                         var_name = "A{}".format(var_count)
                         args.append(var_name)
                         var_count += 1
 
                         # add array declaration to script after the metadata block
-                        bb_array = list_to_blackbird(v, var_name)
+                        bb_array = numpy_to_blackbird(v, var_name)
                         for idx, line in enumerate(bb_array):
                             script.insert(array_insert + idx, line)
 
@@ -342,7 +298,7 @@ class BlackbirdProgram:
 
                     elif isinstance(v, complex):
                         # argument is a complex type
-                        args.append("{}{}{}j".format(v.real, "+-"[int(v.imag < 0)], abs(v.imag)))
+                        args.append("{}{}{}j".format(v.real, "+-"[int(v.imag < 0)], np.abs(v.imag)))
 
                     elif isinstance(v, sym.Expr):
                         # argument contains free parameters
@@ -352,26 +308,23 @@ class BlackbirdProgram:
 
                         args.append(res)
 
-                    elif isinstance(v, (bool, float, int, RegRefTransform)):
+                    else:
                         # anything that doesn't need to be dealt with as a special case,
                         # i.e., booleans, ints, floats.
                         args.append("{}".format(v))
-
-                    else:
-                        raise ValueError("{}: Unknown argument type {}".format(v, type(v)))
 
                 # loop through keyword argument
                 for k, v in op["kwargs"].items():
                     # for each operation argument, format it
                     # correctly depending on its type
-                    if isinstance(v, list):
+                    if isinstance(v, np.ndarray):
                         # create an array variable
                         var_name = "A{}".format(var_count)
                         kwargs.append("{}={}".format(k, var_name))
                         var_count += 1
 
                         # add array declaration to script
-                        bb_array = list_to_blackbird(v, var_name)
+                        bb_array = numpy_to_blackbird(v, var_name)
                         for idx, line in enumerate(bb_array):
                             script.insert(array_insert + idx, line)
 
@@ -382,13 +335,11 @@ class BlackbirdProgram:
 
                     elif isinstance(v, complex):
                         kwargs.append(
-                            "{}={}{}{}j".format(k, v.real, "+-"[int(v.imag < 0)], abs(v.imag))
+                            "{}={}{}{}j".format(k, v.real, "+-"[int(v.imag < 0)], np.abs(v.imag))
                         )
 
-                    elif isinstance(v, (bool, float, int, RegRefTransform)):
-                        kwargs.append("{}={}".format(k, v))
                     else:
-                        raise ValueError("{}, {}: Unknown argument type {}".format(k, v, type(v)))
+                        kwargs.append("{}={}".format(k, v))
 
                 if args and kwargs:
                     arguments = "({}, {})".format(", ".join(args), ", ".join(kwargs))

--- a/blackbird_python/blackbird/tests/test_auxiliary.py
+++ b/blackbird_python/blackbird/tests/test_auxiliary.py
@@ -231,7 +231,7 @@ class TestFunction:
         func = blackbirdParser.FunctionContext(parser, ctx)
         func.ARCCOS = lambda: True
         expression = num(n)
-        assert np.allclose(_func(func, expression), np.arccos(expected))
+        assert _func(func, expression) == np.arccos(expected)
 
     def test_function_arctan(self, parser, ctx, num):
         """Test that a Blackbird arctan function is properly called"""
@@ -275,7 +275,7 @@ class TestFunction:
         func = blackbirdParser.FunctionContext(parser, ctx)
         func.ARCSINH = lambda: True
         expression = num(n)
-        assert np.allclose(_func(func, expression), np.arcsinh(expected))
+        assert _func(func, expression) == np.arcsinh(expected)
 
     @pytest.mark.parametrize('n, expected', test_complex)
     def test_function_arccosh(self, parser, ctx, n, expected, num):
@@ -283,7 +283,7 @@ class TestFunction:
         func = blackbirdParser.FunctionContext(parser, ctx)
         func.ARCCOSH = lambda: True
         expression = num(n)
-        assert np.allclose(_func(func, expression), np.arccosh(expected))
+        assert _func(func, expression) == np.arccosh(expected)
 
     def test_function_arctanh(self, parser, ctx, num):
         """Test that a Blackbird arctanh function is properly called"""
@@ -301,7 +301,7 @@ class TestFunction:
         func = blackbirdParser.FunctionContext(parser, ctx)
         func.SQRT = lambda: True
         expression = num(n)
-        assert np.allclose(_func(func, expression), np.sqrt(expected))
+        assert _func(func, expression) == np.sqrt(expected)
 
     def test_function_invalid(self, parser, ctx):
         """Test that an invalid Blackbird function raises the correct exception"""
@@ -507,7 +507,7 @@ class TestExpressionArray:
             expression = lambda self: (num(n1[0]), var("U"))
 
         with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U": U.tolist()})
+            m.setattr(blackbird.auxiliary, "_VAR", {"U": U})
 
             expr = DummyAddLabel(parser, ctx)
             expr.PLUS = lambda: True
@@ -521,7 +521,7 @@ class TestExpressionArray:
             expression = lambda self: (var("U1"), var("U2"))
 
         with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U1": (U*5).tolist(), "U2": np.cos(U).tolist()})
+            m.setattr(blackbird.auxiliary, "_VAR", {"U1": U*5, "U2": np.cos(U)})
 
             expr = DummyAddLabel(parser, ctx)
             expr.PLUS = lambda: True
@@ -536,22 +536,11 @@ class TestExpressionArray:
             expression = lambda self: (num(n1[0]), var("U"))
 
         with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U": U.tolist()})
+            m.setattr(blackbird.auxiliary, "_VAR", {"U": U})
 
             expr = DummyAddLabel(parser, ctx)
             expr.MINUS = lambda: True
             assert np.all(_expression(expr) == n1[1] - U)
-
-        class DummyAddLabel(blackbirdParser.AddLabelContext):
-            """Dummy add label"""
-            expression = lambda self: (var("U"), num(n1[0]))
-
-        with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U": U.tolist()})
-
-            expr = DummyAddLabel(parser, ctx)
-            expr.MINUS = lambda: True
-            assert np.all(_expression(expr) == U - n1[1])
 
     def test_minus_array(self, parser, ctx, var, monkeypatch):
         """Test subtraction of two arrays"""
@@ -561,7 +550,7 @@ class TestExpressionArray:
             expression = lambda self: (var("U1"), var("U2"))
 
         with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U1": (U*5).tolist(), "U2": np.cos(U).tolist()})
+            m.setattr(blackbird.auxiliary, "_VAR", {"U1": U*5, "U2": np.cos(U)})
 
             expr = DummyAddLabel(parser, ctx)
             expr.MINUS = lambda: True
@@ -576,7 +565,7 @@ class TestExpressionArray:
             expression = lambda self: (num(n1[0]), var("U"))
 
         with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U": U.tolist()})
+            m.setattr(blackbird.auxiliary, "_VAR", {"U": U})
 
             expr = DummyMulLabel(parser, ctx)
             expr.TIMES = lambda: True
@@ -590,7 +579,7 @@ class TestExpressionArray:
             expression = lambda self: (var("U1"), var("U2"))
 
         with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U1": (U*5).tolist(), "U2": np.cos(U).tolist()})
+            m.setattr(blackbird.auxiliary, "_VAR", {"U1": U*5, "U2": np.cos(U)})
 
             expr = DummyMulLabel(parser, ctx)
             expr.TIMES = lambda: True
@@ -605,22 +594,11 @@ class TestExpressionArray:
             expression = lambda self: (num(n1[0]), var("U"))
 
         with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U": U.tolist()})
+            m.setattr(blackbird.auxiliary, "_VAR", {"U": U})
 
             expr = DummyMulLabel(parser, ctx)
             expr.DIVIDE = lambda: True
             assert np.all(_expression(expr) == n1[1]/U)
-
-        class DummyMulLabel(blackbirdParser.MulLabelContext):
-            """Dummy mul label"""
-            expression = lambda self: (var("U"), num(n1[0]))
-
-        with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U": U.tolist()})
-
-            expr = DummyMulLabel(parser, ctx)
-            expr.DIVIDE = lambda: True
-            assert np.all(_expression(expr) == U/n1[1])
 
     def test_divide_array_element(self, parser, ctx, var, monkeypatch):
         """Test division of two arrays"""
@@ -630,48 +608,11 @@ class TestExpressionArray:
             expression = lambda self: (var("U1"), var("U2"))
 
         with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U1": (U*5).tolist(), "U2": np.cos(U).tolist()})
+            m.setattr(blackbird.auxiliary, "_VAR", {"U1": U*5, "U2": np.cos(U)})
 
             expr = DummyMulLabel(parser, ctx)
             expr.DIVIDE = lambda: True
             assert np.allclose(_expression(expr), U*5/np.cos(U))
-
-    @pytest.mark.parametrize('n1', test_complex)
-    def test_pow_scalar_array(self, parser, ctx, n1, num, var, monkeypatch):
-        """Test power of a number and an array"""
-
-        class DummyPowLabel(blackbirdParser.PowerLabelContext):
-            """Dummy power label"""
-            expression = lambda self: (num(n1[0]), var("U"))
-
-        with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U": U.tolist()})
-
-            expr = DummyPowLabel(parser, ctx)
-            assert np.allclose(_expression(expr), n1[1]**U)
-
-        class DummyPowLabel(blackbirdParser.PowerLabelContext):
-            """Dummy power label"""
-            expression = lambda self: (var("U"), num(n1[0]))
-
-        with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U": U.tolist()})
-
-            expr = DummyPowLabel(parser, ctx)
-            assert np.allclose(_expression(expr), U**n1[1])
-
-    def test_pow_array_element(self, parser, ctx, var, monkeypatch):
-        """Test power of two arrays"""
-
-        class DummyPowLabel(blackbirdParser.PowerLabelContext):
-            """Dummy power label"""
-            expression = lambda self: (var("U1"), var("U2"))
-
-        with monkeypatch.context() as m:
-            m.setattr(blackbird.auxiliary, "_VAR", {"U1": (U*5).tolist(), "U2": np.cos(U).tolist()})
-
-            expr = DummyPowLabel(parser, ctx)
-            assert np.allclose(_expression(expr), (U*5)**np.cos(U))
 
 
 class TestArguments:

--- a/blackbird_python/blackbird/tests/test_program.py
+++ b/blackbird_python/blackbird/tests/test_program.py
@@ -21,7 +21,7 @@ import pytest
 import numpy as np
 import sympy as sym
 
-from blackbird.program import BlackbirdProgram, list_to_blackbird
+from blackbird.program import BlackbirdProgram, numpy_to_blackbird
 
 
 class TestNumPyToBlackbird:
@@ -29,22 +29,22 @@ class TestNumPyToBlackbird:
 
     def test_real_array(self):
         """Test real array is correctly formatted"""
-        A = [[0.453, 1, 0.213], [-0.543, 1.342, 1e-4]]
-        res = "\n".join(list_to_blackbird(A, "A"))
+        A = np.array([[0.453, 1, 0.213], [-0.543, 1.342, 1e-4]])
+        res = "\n".join(numpy_to_blackbird(A, "A"))
         expected = "float array A[2, 3] =\n    0.453, 1.0, 0.213\n    -0.543, 1.342, 0.0001\n"
         assert res == expected
 
     def test_int_array(self):
         """Test integer array is correctly formatted"""
-        A = [[1, -0, -15]]
-        res = "\n".join(list_to_blackbird(A, "A"))
+        A = np.array([[1, -0, -15]])
+        res = "\n".join(numpy_to_blackbird(A, "A"))
         expected = "int array A[1, 3] =\n    1, 0, -15\n"
         assert res == expected
 
     def test_complex_array(self):
         """Test complex array is correctly formatted"""
-        A = [[0.453 - 0.543j, 1, 0.213 + 8j], [-0.543j, 1.342 + 0.5j, 1e-4 - 2e2j]]
-        res = "\n".join(list_to_blackbird(A, "A"))
+        A = np.array([[0.453 - 0.543j, 1, 0.213 + 8j], [-0.543j, 1.342 + 0.5j, 1e-4 - 2e2j]])
+        res = "\n".join(numpy_to_blackbird(A, "A"))
         expected = dedent(
             """\
             complex array A[2, 3] =
@@ -56,10 +56,10 @@ class TestNumPyToBlackbird:
 
     def test_unknown_array(self):
         """Test non-numeric array raises an exception"""
-        A = [True, False]
+        A = np.array([True, False])
 
         with pytest.raises(ValueError, match="unsupported type"):
-            list_to_blackbird(A, "A")
+            numpy_to_blackbird(A, "A")
 
 
 class TestBlackbirdProgram:
@@ -185,14 +185,6 @@ class TestBlackbirdSerialize:
         )
         assert res == expected
 
-    def test_serialize_invalid_operation_args(self):
-        """Test serialization of an operation with invalid arg raises error"""
-        bb = BlackbirdProgram(name="prog", version=0.0)
-        bb._operations.append({"op": "Dgate", "modes": [0], "args": [np.array([0.5])], "kwargs": {}})
-
-        with pytest.raises(ValueError, match="Unknown argument type"):
-            res = bb.serialize()
-
     def test_serialize_operation_multiple_args(self):
         """Test serialization of an operation with many args"""
         bb = BlackbirdProgram(name="prog", version=0.0)
@@ -224,14 +216,6 @@ class TestBlackbirdSerialize:
             """
         )
         assert res == expected
-
-    def test_serialize_invalid_operation_kwargs(self):
-        """Test serialization of an operation with invalid arg raises error"""
-        bb = BlackbirdProgram(name="prog", version=0.0)
-        bb._operations.append({"op": "Dgate", "modes": [0], "args": [], "kwargs": {"U": np.array([0.5])}})
-
-        with pytest.raises(ValueError, match="Unknown argument type"):
-            res = bb.serialize()
 
     def test_serialize_operation_multiple_kwargs(self):
         """Test serialization of an operation with many kwargs"""
@@ -296,7 +280,7 @@ class TestBlackbirdSerialize:
     def test_serialize_operation_array_arg(self):
         """Test serialization of an operation with an array arg"""
         bb = BlackbirdProgram(name="prog", version=0.0)
-        U = np.int64(np.identity(2)).tolist()
+        U = np.int64(np.identity(2))
 
         bb._operations.append({"op": "Interferometer", "modes": [0], "args": [U], "kwargs": {}})
 
@@ -318,7 +302,7 @@ class TestBlackbirdSerialize:
     def test_serialize_operation_array_kwarg(self):
         """Test serialization of an operation with an array kwarg"""
         bb = BlackbirdProgram(name="prog", version=0.0)
-        U = np.int64(np.identity(2)).tolist()
+        U = np.int64(np.identity(2))
 
         bb._operations.append(
             {"op": "Interferometer", "modes": [0], "args": [], "kwargs": {"U": U}}
@@ -388,8 +372,8 @@ class TestBlackbirdSerialize:
     def test_serialize_operation_multiple_arrays(self):
         """Test serialization of an operation with multiple array args"""
         bb = BlackbirdProgram(name="prog", version=0.0)
-        U = np.int64(np.identity(2)).tolist()
-        U2 = np.array([[1, 2j], [-2j, 3]]).tolist()
+        U = np.int64(np.identity(2))
+        U2 = np.array([[1, 2j], [-2j, 3]])
 
         bb._operations.extend(
             [

--- a/blackbird_python/blackbird/utils.py
+++ b/blackbird_python/blackbird/utils.py
@@ -40,6 +40,7 @@ Code details
 """
 from collections import namedtuple
 
+import numpy as np
 import sympy as sym
 from sympy.solvers import solve
 
@@ -216,7 +217,7 @@ def match_template(template, program):
 
     for n1, n2 in GM.mapping.items():
         for x, y in zip(G1nodes[n1]['args'], G2nodes[n2]['args']):
-            if x != y:
+            if np.all(x != y):
                 if isinstance(x, sym.Symbol):
                     key = str(x)
                     val = y

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 antlr4-python3-runtime==4.7.2
+numpy>=1.16
 sympy
 networkx

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ with open("blackbird_python/blackbird/_version.py") as f:
 	version = f.readlines()[-1].split()[-1].strip("\"'")
 
 requirements = [
+    "numpy>=1.16",
     "sympy",
     "antlr4-python3-runtime>=4.7.2",
     "networkx"


### PR DESCRIPTION
This PR reverts #17, as this change will need to be done across the platform. Furthermore, removing NumPy is not critical, as most environments that use Blackbird will likely also have SF installed (which depends on NumPy)