### PR TITLE
Remove type from test_file

### DIFF
--- a/blackbird_python/blackbird/tests/test_listener.py
+++ b/blackbird_python/blackbird/tests/test_listener.py
@@ -35,7 +35,6 @@ test_file = """
 name test_name
 version 1.0
 target fock (num_subsystems=1, cutoff_dim=7, shots=10)
-type TDM (copies=1000)
 
 float alpha = 0.3423
 Coherent(alpha, sqrt(pi)) | 0


### PR DESCRIPTION
Removes the `type TDM (copies=1000)` line from the global `test_file` BB script in "test_listener.py", since it's not needed (and might obscure certain test cases). A post-fix for PR #30.