### PR TITLE
Increment version number to 0.3.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -29,12 +29,12 @@
 
 * Keyword arguments are supported inside operations; for example,
   `MeasureHomodyne(select=[0, 1])` or `MeasureFock(dark_counts=[1, 0.5, 3])`.
-  [(#22)](https://github.com/XanaduAI/blackbird/pull/23)
+  [(#23)](https://github.com/XanaduAI/blackbird/pull/23)
 
 * Indexing is supported inside both modes and arguments; for example,
   `MZgate(list[2], list[0]) | [list[3], list[1]]))`. All indices allow
   expressions such as `phases[-3 + 2*2]`.
-  [(#22)](https://github.com/XanaduAI/blackbird/pull/23)
+  [(#23)](https://github.com/XanaduAI/blackbird/pull/23)
 
 <h3>Bug fixes</h3>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.2.5 (development release)
+# Release 0.3.0
 
 <h3>New features since last release</h3>
 
@@ -28,7 +28,7 @@
   ```
 
 * Keyword arguments are supported inside operations; for example,
-  `MeasureHomodyne(select=[0, 1])` or `MeasureFock(dark_counts=[1, 0.5, 3])`
+  `MeasureHomodyne(select=[0, 1])` or `MeasureFock(dark_counts=[1, 0.5, 3])`.
   [(#22)](https://github.com/XanaduAI/blackbird/pull/23)
 
 * Indexing is supported inside both modes and arguments; for example,
@@ -36,16 +36,17 @@
   expressions such as `phases[-3 + 2*2]`.
   [(#22)](https://github.com/XanaduAI/blackbird/pull/23)
 
-<h3>Improvements</h3>
-
-<h3>Breaking changes</h3>
-
 <h3>Bug fixes</h3>
 
-* Templates are no longer changed when calling them and replacing the parameters with actual values.
+* Templates are no longer changed when calling them and replacing the parameters
+  with actual values.
   [(#34)](https://github.com/XanaduAI/blackbird/pull/34)
 
 <h3>Documentation</h3>
+
+* TDM programs, for-loops and array indexing is added to the docs, along with
+  other minor updates.
+  [(#28)](https://github.com/XanaduAI/blackbird/pull/28)
 
 This release contains contributions from (in alphabetical order):
 

--- a/blackbird_python/blackbird/_version.py
+++ b/blackbird_python/blackbird/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.2.3'
+__version__ = '0.3.0'


### PR DESCRIPTION
Increments the version number of Blackbird to 0.3.0, adding support for e.g. TDM programs and for-loops.