### PR TITLE
Fix nonumerics in for-loops

### DIFF
--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -521,10 +521,13 @@ class BlackbirdListener(blackbirdListener):
                 if c.getText() != ":"
             ])
         elif ctx.vallist():
-            for_var = [
-                _expression(c.expression()) for c in ctx.vallist().getChildren()
-                if isinstance(c, blackbirdParser.ValContext)
-            ]
+            for_var = []
+            for c in ctx.vallist().getChildren():
+                if isinstance(c, blackbirdParser.ValContext):
+                    if c.expression() is not None:
+                        for_var.append(_expression(c.expression()))
+                    elif c.nonnumeric() is not None:
+                        for_var.append(_literal(c.nonnumeric()))
 
         for var in for_var:
             if ctx.NAME():

--- a/blackbird_python/blackbird/tests/test_listener.py
+++ b/blackbird_python/blackbird/tests/test_listener.py
@@ -832,16 +832,16 @@ class TestParsingForLoops:
             {'op': 'MeasureFock', 'args': [], 'kwargs': {}, 'modes': [modes[1]]},
             {'op': 'MeasureFock', 'args': [], 'kwargs': {}, 'modes': [modes[2]]}
         ]
-        
+
     def test_for_bool(self, parse_input_mocked_metadata):
         """Test that a for-loop over a list containing bools is parsed correctly"""
         bb = parse_input_mocked_metadata(
-            "for bool b in [True, False]\n\tMeasureFock() | 0"
+            "for bool b in [True, False]\n\tUnaryGate(b, 0) | 0"
         )
         assert np.all(
             bb._forvar["b"] == np.array([True, False])
         )
-        
+
     def test_for_str(self, parse_input_mocked_metadata):
         """Test that a for-loop over a list containing strings is parsed correctly"""
         bb = parse_input_mocked_metadata(

--- a/blackbird_python/blackbird/tests/test_listener.py
+++ b/blackbird_python/blackbird/tests/test_listener.py
@@ -832,6 +832,24 @@ class TestParsingForLoops:
             {'op': 'MeasureFock', 'args': [], 'kwargs': {}, 'modes': [modes[1]]},
             {'op': 'MeasureFock', 'args': [], 'kwargs': {}, 'modes': [modes[2]]}
         ]
+        
+    def test_for_bool(self, parse_input_mocked_metadata):
+        """Test that a for-loop over a list containing bools is parsed correctly"""
+        bb = parse_input_mocked_metadata(
+            "for bool b in [True, False]\n\tMeasureFock() | 0"
+        )
+        assert np.all(
+            bb._forvar["b"] == np.array([True, False])
+        )
+        
+    def test_for_str(self, parse_input_mocked_metadata):
+        """Test that a for-loop over a list containing strings is parsed correctly"""
+        bb = parse_input_mocked_metadata(
+            'for str s in ["one", "two"]\n\tMeasureFock() | 0'
+        )
+        assert np.all(
+            bb._forvar["s"] == np.array(["one", "two"])
+        )
 
     @pytest.mark.parametrize("rnge", ["2:10:3", "3:6"])
     def test_for_range(self, rnge, parse_input_mocked_metadata):


### PR DESCRIPTION
Using bool or string in for loop iterators isn't working properly. Currently, it returns None, instead of the wanted string or bool. This PR fixes the issue, so that e.g. the following works.

```# a test blackbird script
name test_name
version 1.0
target fock (num_subsystems=1, cutoff_dim=7, shots=10)

for bool i in [True, False]
    UnaryGate(i, {param}) | 0
```