### PR TITLE
Fix deprecation of `np.str` and `np.bool`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 <h3>Bug fixes</h3>
 
+* Update the NumPy scalar types in the Blackbird listener due to being deprecated in NumPy 1.20.
+  [(#43)](https://github.com/XanaduAI/blackbird/pull/43)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -75,8 +75,8 @@ NUMPY_TYPES = {
     "float": np.float64,
     "complex": np.complex128,
     "int": np.int64,
-    "str": np.str,
-    "bool": np.bool,
+    "str": np.str_,
+    "bool": np.bool_,
 }
 """dict[str->type]: Mapping from the allowed Blackbird array types
 to the equivalent NumPy data types."""


### PR DESCRIPTION
Updates `np.str` and `np.bool` to `np.str_` and `np.bool_` in Blackbird listener.