### PR TITLE
Add `expr` to RegRefTransform class

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,6 +17,10 @@
 * Update the NumPy scalar types in the Blackbird listener due to being deprecated in NumPy 1.20.
   [(#43)](https://github.com/XanaduAI/blackbird/pull/43)
 
+* Add access to the symbolic expression used when creating a `RegRefTransform`,
+  as a class attribute.
+  [(#46)](https://github.com/XanaduAI/blackbird/pull/46)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -90,16 +90,20 @@ class RegRefTransform:
     """
 
     def __init__(self, expr):
-        """After initialization, the RegRefTransform has three attributes
+        """After initialization, the RegRefTransform has four attributes
         which may be inspected to translate the Blackbird program to a
         simulator or quantum hardware:
 
+        * :attr:`expr`
         * :attr:`func`
         * :attr:`regrefs`
         * :attr:`func_str`
         """
         regref_symbols = list(expr.free_symbols)
+
         self.expr = expr
+        """sympy.Expr: The input symbolic expression."""
+
         # get the Python function represented by the regref transform
         self.func = sym.lambdify(regref_symbols, expr)
         """function: Scalar function that takes one or more values corresponding

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -99,6 +99,7 @@ class RegRefTransform:
         * :attr:`func_str`
         """
         regref_symbols = list(expr.free_symbols)
+        self.expr = expr
         # get the Python function represented by the regref transform
         self.func = sym.lambdify(regref_symbols, expr)
         """function: Scalar function that takes one or more values corresponding


### PR DESCRIPTION
This is part of an attempt to keep support for feed-forwarding when serializing and deserializing a Blackbird script. To be able to use a `RegRefTransform` type parameter as a symbolic expression in Strawberry Fields it needs to be accessible from the `RegRefTransform` class.

Below is an example that, when loaded as a Blackbird program and then transformed into an SF program, needs access to the `Xgate` and `Zgate` parameters symbolic expressions (instead of only as a `RegRefTransform`).

```
name Teleportation
version 1.0
target gaussian

Coherent(1, 0.0) | 0
Sgate(2, 0) | 2
Sgate(-2, 0) | 1
BSgate(0.7854, 0) | [1, 2]
BSgate(0.7854, 0) | [0, 1]
MeasureHomodyne(phi=1.5707963267948966) | 1
MeasureHomodyne(phi=0) | 0
Xgate(1.41421356237*q0) | 2
Zgate(1.41421356237*q1) | 2
```

By allowing this, we can load a script with Blackbird and then transform it into a valid Strawberry Fields program that contains feedforwarding.

**Note**: currently, Strawberry Fields converts the `1.41421356237*q0` parameter into a string while creating the Blackbird program. This has to be updated to keep it as a symbolic expression instead.