### PR TITLE
Access p-type variables

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,7 +11,7 @@
   [(#39)](https://github.com/XanaduAI/blackbird/pull/39)
 
 * Add public method to retrieve Blackbird program variables via `prog.variables`.
-[(#47)](https://github.com/XanaduAI/blackbird/pull/47)
+  [(#47)](https://github.com/XanaduAI/blackbird/pull/47)
 
 * Improve `match_template` to automatically return matched parameters with their array values,
   rather than their array names (p0, p1, etc.)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,13 @@
 * Add support for Python 3.8 and 3.9.
   [(#39)](https://github.com/XanaduAI/blackbird/pull/39)
 
+* Add public method to retrieve Blackbird program variables via `prog.variables`.
+[(#47)](https://github.com/XanaduAI/blackbird/pull/47)
+
+* Improve `match_template` to automatically return matched parameters with their array values,
+  rather than their array names (p0, p1, etc.)
+  [(#47)](https://github.com/XanaduAI/blackbird/pull/47)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -20,6 +27,11 @@
 * Add access to the symbolic expression used when creating a `RegRefTransform`,
   as a class attribute.
   [(#46)](https://github.com/XanaduAI/blackbird/pull/46)
+
+* Remove p-type parameters from `prog.parameters` since they're only needed there internally and
+  are otherwise stored in `prog.variables`. This also changes TDM programs to not be templates
+  (`prog.is_template` now returns `False`).
+  [(#47)](https://github.com/XanaduAI/blackbird/pull/47)
 
 <h3>Documentation</h3>
 

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -561,7 +561,8 @@ class BlackbirdListener(blackbirdListener):
         self._program._var.update(_VAR)
         _VAR.clear()
 
-        self._program._parameters.extend(_PARAMS)
+        is_ptype = lambda p: p.name[0] == "p" and p.name[1:].isdigit()
+        self._program._parameters.extend([p for p in _PARAMS if not is_ptype(p)])
         _PARAMS.clear()
 
     def enterProgram(self, ctx: blackbirdParser.ProgramContext):

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -561,7 +561,7 @@ class BlackbirdListener(blackbirdListener):
         self._program._var.update(_VAR)
         _VAR.clear()
 
-        is_ptype = lambda p: p.name[0] == "p" and p.name[1:].isdigit()
+        is_ptype = lambda p: str(p)[0] == "p" and str(p)[1:].isdigit()
         self._program._parameters.extend([p for p in _PARAMS if not is_ptype(p)])
         _PARAMS.clear()
 

--- a/blackbird_python/blackbird/listener.py
+++ b/blackbird_python/blackbird/listener.py
@@ -82,6 +82,11 @@ NUMPY_TYPES = {
 to the equivalent NumPy data types."""
 
 
+def is_ptype(p):
+    """Checks whether a parameter is in the form `p0`, `p1`, etc."""
+    return str(p)[0] == "p" and str(p)[1:].isdigit()
+
+
 class RegRefTransform:
     """Class to represent a classical register transform.
 
@@ -404,7 +409,7 @@ class BlackbirdListener(blackbirdListener):
         # value during expression evaluation; although, since it always has an
         # accompanying variable it also needs to be stored in `_VAR` with its
         # corresponding value
-        if self._program._type["name"] == "tdm" and name[0] == "p" and name[1:].isdigit():
+        if self._program._type["name"] == "tdm" and is_ptype(name):
             _PARAMS.append(name)
         _VAR[name] = final_value
 
@@ -561,7 +566,6 @@ class BlackbirdListener(blackbirdListener):
         self._program._var.update(_VAR)
         _VAR.clear()
 
-        is_ptype = lambda p: str(p)[0] == "p" and str(p)[1:].isdigit()
         self._program._parameters.extend([p for p in _PARAMS if not is_ptype(p)])
         _PARAMS.clear()
 

--- a/blackbird_python/blackbird/program.py
+++ b/blackbird_python/blackbird/program.py
@@ -189,6 +189,15 @@ class BlackbirdProgram:
         """
         return set([str(i) for i in self._parameters])
 
+    @property
+    def variables(self):
+        """List of variables in the Blackbird program.
+
+        Returns:
+            dict[str, float]: dictionary of variables
+        """
+        return self._var
+
     def is_template(self):
         """Returns ``True`` if there is at least one free parameter.
 

--- a/blackbird_python/blackbird/tests/test_program.py
+++ b/blackbird_python/blackbird/tests/test_program.py
@@ -70,7 +70,7 @@ class TestBlackbirdProgram:
     def test_initialization(self):
         """Test all attributes correctly initialized"""
         bb = BlackbirdProgram(name="prog", version=0.0)
-        assert not bb._var
+        assert not bb.variables
 
         assert bb.name == "prog"
         assert bb.version == 0.0
@@ -501,7 +501,7 @@ class TestProgramIntegration:
 
         expected = {'one': np.array([[11, 12]]), 'two': np.array([[1, 22, 3], [1, 2, 33]]), 'four': 44}
 
-        assert np.all(np.all(v == expected[k]) for k, v in bb2._var.items())
+        assert np.all(np.all(v == expected[k]) for k, v in bb2.variables.items())
 
         assert bb2.operations[0] == {'op': 'Sgate', 'args': [1, 0], 'kwargs': {}, 'modes': [1]}
         assert bb2.operations[1] == {'op': 'BSgate', 'args': [11], 'kwargs': {}, 'modes': [1, 0]}
@@ -551,7 +551,7 @@ class TestProgramIntegration:
         assert bb.is_template()
 
         bb2 = bb(p_one=array)
-        assert np.all(bb2._var["one"] == np.array(array)[:1, :2])
+        assert np.all(bb2.variables["one"] == np.array(array)[:1, :2])
 
     def test_error_no_shape_in_template_array(self):
         """Test that an error is raised when omitting shape when defining a template array."""

--- a/blackbird_python/blackbird/utils.py
+++ b/blackbird_python/blackbird/utils.py
@@ -242,4 +242,9 @@ def match_template(template, program):
                 if key != "":
                     argmatch[key] = val
 
+    p_params = {
+        k: program.variables[str(v)] for k, v in argmatch.items() if str(v) in program.variables
+    }
+    argmatch.update(p_params)
+
     return argmatch


### PR DESCRIPTION
* Adds a public method to retrieve Blackbird program variables via `prog.variables`
* Improves `match_template` to automatically return matched parameters with their array values, rather than their array names (`p0`, `p1`, etc.)
* Removes p-type parameters from `prog.parameters` since they're only needed there internally and are otherwise stored in `prog.variables`. This also changes TDM programs to _not_ be templates (`prog.is_template` now returns `False`).