### PR TITLE
Increment version to 0.5.0-dev

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,22 @@
-# Release 0.4.0
+# Release 0.5.0 (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements</h3>
+
+<h3>Breaking changes</h3>
+
+<h3>Bug fixes</h3>
+
+<h3>Documentation</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+---
+
+# Release 0.4.0 (current release)
 
 <h3>Improvements</h3>
 
@@ -37,6 +55,8 @@
 This release contains contributions from (in alphabetical order):
 
 Theodor Isacsson
+
+---
 
 # Release 0.3.0
 

--- a/blackbird_python/blackbird/_version.py
+++ b/blackbird_python/blackbird/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.4.0'
+__version__ = '0.5.0-dev'


### PR DESCRIPTION
Blackbird v0.4.0 has been release. Thus, we increment the version number to 0.5.0-dev. 🐦 